### PR TITLE
Enable deletion of SageMaker job style CR from API server if job is complete

### DIFF
--- a/generator.yaml
+++ b/generator.yaml
@@ -1,27 +1,15 @@
 operations:
-  CreateTrainingJob:
-    set_output_custom_method_name: customCreateTrainingJobSetOutput
   DescribeTrainingJob:
     set_output_custom_method_name: customDescribeTrainingJobSetOutput
   StopTrainingJob:
     operation_type: Delete
     resource_name: TrainingJob
-  CreateProcessingJob:
-    set_output_custom_method_name: customCreateProcessingJobSetOutput
-  DescribeProcessingJob:
-    set_output_custom_method_name: customDescribeProcessingJobSetOutput
   StopProcessingJob:
     operation_type: Delete
     resource_name: ProcessingJob
-  CreateTransformJob:
-    set_output_custom_method_name: customCreateTransformJobSetOutput
-  DescribeTransformJob:
-    set_output_custom_method_name: customDescribeTransformJobSetOutput
   StopTransformJob:
     operation_type: Delete
     resource_name: TransformJob
-  CreateEndpoint:
-    set_output_custom_method_name: customCreateEndpointSetOutput
   DescribeEndpoint:
     set_output_custom_method_name: customDescribeEndpointSetOutput
   UpdateEndpoint:
@@ -31,10 +19,6 @@ operations:
       RetainAllVariantProperties: true
   DeleteEndpoint:
     custom_implementation: customDeleteEndpoint
-  CreateHyperParameterTuningJob:
-    set_output_custom_method_name: customCreateHyperParameterTuningJobSetOutput
-  DescribeHyperParameterTuningJob:
-    set_output_custom_method_name: customDescribeHyperParameterTuningJobSetOutput
   StopHyperParameterTuningJob:
     operation_type: Delete
     resource_name: HyperParameterTuningJob
@@ -100,6 +84,9 @@ resources:
         - MalformedQueryString
         - InvalidAction
         - UnrecognizedClientException
+    hooks:
+      sdk_create_post_set_output:
+        code: rm.customSetOutput(r, aws.String(svcsdk.EndpointStatusCreating), ko)
     fields:
       EndpointStatus:
         is_read_only: true
@@ -158,6 +145,11 @@ resources:
         - MalformedQueryString
         - InvalidAction
         - UnrecognizedClientException
+    hooks:
+      sdk_create_post_set_output:
+        code: rm.customSetOutput(r, aws.String(svcsdk.TrainingJobStatusInProgress), ko)
+      sdk_delete_pre_build_request:
+        template_path: training_job/sdk_delete_pre_build_request.go.tpl
     fields:
       TrainingJobStatus:
           is_read_only: true
@@ -202,6 +194,13 @@ resources:
         - MalformedQueryString
         - InvalidAction
         - UnrecognizedClientException
+    hooks:
+      sdk_delete_pre_build_request:
+        template_path: processing_job/sdk_delete_pre_build_request.go.tpl
+      sdk_create_post_set_output:
+        code: rm.customSetOutput(r, aws.String(svcsdk.ProcessingJobStatusInProgress), ko)
+      sdk_read_one_post_set_output:
+        code: rm.customSetOutput(r, resp.ProcessingJobStatus, ko)
     fields:
       ProcessingJobStatus:
         is_read_only: true
@@ -235,6 +234,13 @@ resources:
         - MalformedQueryString
         - InvalidAction
         - UnrecognizedClientException
+    hooks:
+      sdk_delete_pre_build_request:
+        template_path: transform_job/sdk_delete_pre_build_request.go.tpl
+      sdk_create_post_set_output:
+        code: rm.customSetOutput(r, aws.String(svcsdk.TransformJobStatusInProgress), ko)
+      sdk_read_one_post_set_output:
+        code: rm.customSetOutput(r, resp.TransformJobStatus, ko)
     fields:
       TransformJobStatus:
           is_read_only: true
@@ -267,6 +273,13 @@ resources:
         - MalformedQueryString
         - InvalidAction
         - UnrecognizedClientException
+    hooks:
+      sdk_delete_pre_build_request:
+        template_path: hyper_parameter_tuning_job/sdk_delete_pre_build_request.go.tpl
+      sdk_create_post_set_output:
+        code: rm.customSetOutput(r, aws.String(svcsdk.HyperParameterTuningJobStatusInProgress), ko)
+      sdk_read_one_post_set_output:
+        code: rm.customSetOutput(r, resp.HyperParameterTuningJobStatus, ko)
     fields:
       HyperParameterTuningJobStatus:
         is_read_only: true

--- a/pkg/resource/endpoint/custom_set_output.go
+++ b/pkg/resource/endpoint/custom_set_output.go
@@ -26,19 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// customCreateEndpointSetOutput sets the resource in TempOutofSync if endpoint is
-// in creating state. At this stage we know call to createEndpoint was successful.
-func (rm *resourceManager) customCreateEndpointSetOutput(
-	ctx context.Context,
-	r *resource,
-	resp *svcsdk.CreateEndpointOutput,
-	ko *svcapitypes.Endpoint,
-) (*svcapitypes.Endpoint, error) {
-	rm.customSetOutput(r, aws.String(svcsdk.EndpointStatusCreating), ko)
-	return ko, nil
-}
-
-// customDescribeEndpointSetOutput sets the resource in TempOutofSync if endpoint is
+// customDescribeEndpointSetOutput sets the resource ResourceSynced condition to False if endpoint is
 // being modified by AWS
 func (rm *resourceManager) customDescribeEndpointSetOutput(
 	ctx context.Context,
@@ -63,7 +51,7 @@ func (rm *resourceManager) customDescribeEndpointSetOutput(
 	return ko, nil
 }
 
-// customUpdateEndpointSetOutput sets the resource in TempOutofSync if endpoint is
+// customUpdateEndpointSetOutput sets the resource ResourceSynced condition to False if endpoint is
 // being updated. At this stage we know call to updateEndpoint was successful.
 func (rm *resourceManager) customUpdateEndpointSetOutput(
 	ctx context.Context,

--- a/pkg/resource/endpoint/sdk.go
+++ b/pkg/resource/endpoint/sdk.go
@@ -216,12 +216,7 @@ func (rm *resourceManager) sdkCreate(
 
 	rm.setStatusDefaults(ko)
 
-	// custom set output from response
-	ko, err = rm.customCreateEndpointSetOutput(ctx, r, resp, ko)
-	if err != nil {
-		return nil, err
-	}
-
+	rm.customSetOutput(r, aws.String(svcsdk.EndpointStatusCreating), ko)
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/hyper_parameter_tuning_job/custom_set_output.go
+++ b/pkg/resource/hyper_parameter_tuning_job/custom_set_output.go
@@ -17,38 +17,11 @@
 package hyper_parameter_tuning_job
 
 import (
-	"context"
-
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	svcapitypes "github.com/aws-controllers-k8s/sagemaker-controller/apis/v1alpha1"
-	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
 	corev1 "k8s.io/api/core/v1"
 )
-
-// customCreateHyperParameterTuningJobSetOutput sets the resource in TempOutofSync if HyperParameterTuningJob is
-// in creating state. At this stage we know call to createHyperParameterTuningJob was successful.
-func (rm *resourceManager) customCreateHyperParameterTuningJobSetOutput(
-	ctx context.Context,
-	r *resource,
-	resp *svcsdk.CreateHyperParameterTuningJobOutput,
-	ko *svcapitypes.HyperParameterTuningJob,
-) (*svcapitypes.HyperParameterTuningJob, error) {
-	rm.customSetOutput(r, aws.String(svcsdk.HyperParameterTuningJobStatusInProgress), ko)
-	return ko, nil
-}
-
-// customDescribeHyperParameterTuningJobSetOutput sets the resource in TempOutofSync if
-// HyperParameterTuningJob is being modified by AWS.
-func (rm *resourceManager) customDescribeHyperParameterTuningJobSetOutput(
-	ctx context.Context,
-	r *resource,
-	resp *svcsdk.DescribeHyperParameterTuningJobOutput,
-	ko *svcapitypes.HyperParameterTuningJob,
-) (*svcapitypes.HyperParameterTuningJob, error) {
-	rm.customSetOutput(r, resp.HyperParameterTuningJobStatus, ko)
-	return ko, nil
-}
 
 // customSetOutput sets ConditionTypeResourceSynced condition to True or False
 // based on the hyperParameterTuningJobStatus on AWS so the reconciler can determine if a

--- a/pkg/resource/hyper_parameter_tuning_job/sdk.go
+++ b/pkg/resource/hyper_parameter_tuning_job/sdk.go
@@ -881,12 +881,7 @@ func (rm *resourceManager) sdkFind(
 
 	rm.setStatusDefaults(ko)
 
-	// custom set output from response
-	ko, err = rm.customDescribeHyperParameterTuningJobSetOutput(ctx, r, resp, ko)
-	if err != nil {
-		return nil, err
-	}
-
+	rm.customSetOutput(r, resp.HyperParameterTuningJobStatus, ko)
 	return &resource{ko}, nil
 }
 
@@ -944,12 +939,7 @@ func (rm *resourceManager) sdkCreate(
 
 	rm.setStatusDefaults(ko)
 
-	// custom set output from response
-	ko, err = rm.customCreateHyperParameterTuningJobSetOutput(ctx, r, resp, ko)
-	if err != nil {
-		return nil, err
-	}
-
+	rm.customSetOutput(r, aws.String(svcsdk.HyperParameterTuningJobStatusInProgress), ko)
 	return &resource{ko}, nil
 }
 
@@ -1646,6 +1636,12 @@ func (rm *resourceManager) sdkDelete(
 	ctx context.Context,
 	r *resource,
 ) error {
+	// Call StopHyperparameterTuningJob only if the job is InProgress, otherwise just return nil to mark the
+	// resource Unmanaged
+	latestStatus := r.ko.Status.HyperParameterTuningJobStatus
+	if latestStatus != nil && *latestStatus != svcsdk.HyperParameterTuningJobStatusInProgress {
+		return nil
+	}
 
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {

--- a/pkg/resource/processing_job/custom_set_output.go
+++ b/pkg/resource/processing_job/custom_set_output.go
@@ -17,38 +17,11 @@
 package processing_job
 
 import (
-	"context"
-
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	svcapitypes "github.com/aws-controllers-k8s/sagemaker-controller/apis/v1alpha1"
-	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
 	corev1 "k8s.io/api/core/v1"
 )
-
-// customCreateProcessingJobSetOutput sets the resource in TempOutofSync if ProcessingJob is
-// in creating state. At this stage we know call to createProcessingJob was successful.
-func (rm *resourceManager) customCreateProcessingJobSetOutput(
-	ctx context.Context,
-	r *resource,
-	resp *svcsdk.CreateProcessingJobOutput,
-	ko *svcapitypes.ProcessingJob,
-) (*svcapitypes.ProcessingJob, error) {
-	rm.customSetOutput(r, aws.String(svcsdk.ProcessingJobStatusInProgress), ko)
-	return ko, nil
-}
-
-// customDescribeProcessingJobSetOutput sets the resource in TempOutofSync if
-// ProcessingJob is being modified by AWS.
-func (rm *resourceManager) customDescribeProcessingJobSetOutput(
-	ctx context.Context,
-	r *resource,
-	resp *svcsdk.DescribeProcessingJobOutput,
-	ko *svcapitypes.ProcessingJob,
-) (*svcapitypes.ProcessingJob, error) {
-	rm.customSetOutput(r, resp.ProcessingJobStatus, ko)
-	return ko, nil
-}
 
 // customSetOutput sets ConditionTypeResourceSynced condition to True or False
 // based on the processingJobStatus on AWS so the reconciler can determine if a

--- a/pkg/resource/training_job/custom_set_output.go
+++ b/pkg/resource/training_job/custom_set_output.go
@@ -26,19 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// customCreateTrainingJobSetOutput sets the resource in TempOutofSync if TrainingJob is
-// in creating state. At this stage we know call to createTrainingJob was successful.
-func (rm *resourceManager) customCreateTrainingJobSetOutput(
-	ctx context.Context,
-	r *resource,
-	resp *svcsdk.CreateTrainingJobOutput,
-	ko *svcapitypes.TrainingJob,
-) (*svcapitypes.TrainingJob, error) {
-	rm.customSetOutput(r, aws.String(svcsdk.TrainingJobStatusInProgress), ko)
-	return ko, nil
-}
-
-// customDescribeTrainingJobSetOutput sets the resource in TempOutofSync if
+// customDescribeTrainingJobSetOutput sets the resource ResourceSynced condition to False if
 // TrainingJob is being modified by AWS. It has an additional check on the debugger status.
 func (rm *resourceManager) customDescribeTrainingJobSetOutput(
 	ctx context.Context,

--- a/pkg/resource/training_job/sdk.go
+++ b/pkg/resource/training_job/sdk.go
@@ -578,12 +578,7 @@ func (rm *resourceManager) sdkCreate(
 
 	rm.setStatusDefaults(ko)
 
-	// custom set output from response
-	ko, err = rm.customCreateTrainingJobSetOutput(ctx, r, resp, ko)
-	if err != nil {
-		return nil, err
-	}
-
+	rm.customSetOutput(r, aws.String(svcsdk.TrainingJobStatusInProgress), ko)
 	return &resource{ko}, nil
 }
 
@@ -970,6 +965,12 @@ func (rm *resourceManager) sdkDelete(
 	ctx context.Context,
 	r *resource,
 ) error {
+	// Call StopTrainingJob only if the job is InProgress, otherwise just return nil to mark the
+	// resource Unmanaged
+	latestStatus := r.ko.Status.TrainingJobStatus
+	if latestStatus != nil && *latestStatus != svcsdk.TrainingJobStatusInProgress {
+		return nil
+	}
 
 	input, err := rm.newDeleteRequestPayload(r)
 	if err != nil {

--- a/pkg/resource/transform_job/custom_set_output.go
+++ b/pkg/resource/transform_job/custom_set_output.go
@@ -17,38 +17,11 @@
 package transform_job
 
 import (
-	"context"
-
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	svcapitypes "github.com/aws-controllers-k8s/sagemaker-controller/apis/v1alpha1"
-	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
 	corev1 "k8s.io/api/core/v1"
 )
-
-// customCreateTransformJobSetOutput sets the resource in TempOutofSync if TransformJob is
-// in creating state. At this stage we know call to createTransformJob was successful.
-func (rm *resourceManager) customCreateTransformJobSetOutput(
-	ctx context.Context,
-	r *resource,
-	resp *svcsdk.CreateTransformJobOutput,
-	ko *svcapitypes.TransformJob,
-) (*svcapitypes.TransformJob, error) {
-	rm.customSetOutput(r, aws.String(svcsdk.TransformJobStatusInProgress), ko)
-	return ko, nil
-}
-
-// customDescribeTransformJobSetOutput sets the resource in TempOutofSync if
-// TransformJob is being modified by AWS.
-func (rm *resourceManager) customDescribeTransformJobSetOutput(
-	ctx context.Context,
-	r *resource,
-	resp *svcsdk.DescribeTransformJobOutput,
-	ko *svcapitypes.TransformJob,
-) (*svcapitypes.TransformJob, error) {
-	rm.customSetOutput(r, resp.TransformJobStatus, ko)
-	return ko, nil
-}
 
 // customSetOutput sets ConditionTypeResourceSynced condition to True or False
 // based on the transformJobStatus on AWS so the reconciler can determine if a

--- a/templates/hyper_parameter_tuning_job/sdk_delete_pre_build_request.go.tpl
+++ b/templates/hyper_parameter_tuning_job/sdk_delete_pre_build_request.go.tpl
@@ -1,0 +1,6 @@
+    // Call StopHyperparameterTuningJob only if the job is InProgress, otherwise just return nil to mark the
+	// resource Unmanaged
+	latestStatus := r.ko.Status.HyperParameterTuningJobStatus
+	if latestStatus != nil && *latestStatus != svcsdk.HyperParameterTuningJobStatusInProgress {
+		return nil
+	}

--- a/templates/processing_job/sdk_delete_pre_build_request.go.tpl
+++ b/templates/processing_job/sdk_delete_pre_build_request.go.tpl
@@ -1,0 +1,6 @@
+    // Call StopProcessingJob only if the job is InProgress, otherwise just return nil to mark the
+	// resource Unmanaged
+	latestStatus := r.ko.Status.ProcessingJobStatus
+	if latestStatus != nil && *latestStatus != svcsdk.ProcessingJobStatusInProgress {
+		return nil
+	}

--- a/templates/training_job/sdk_delete_pre_build_request.go.tpl
+++ b/templates/training_job/sdk_delete_pre_build_request.go.tpl
@@ -1,0 +1,6 @@
+    // Call StopTrainingJob only if the job is InProgress, otherwise just return nil to mark the
+	// resource Unmanaged
+	latestStatus := r.ko.Status.TrainingJobStatus
+	if latestStatus != nil && *latestStatus != svcsdk.TrainingJobStatusInProgress {
+		return nil
+	}

--- a/templates/transform_job/sdk_delete_pre_build_request.go.tpl
+++ b/templates/transform_job/sdk_delete_pre_build_request.go.tpl
@@ -1,0 +1,6 @@
+	// Call StopTranformJob only if the job is InProgress, otherwise just return nil to mark the
+	// resource Unmanaged
+	latestStatus := r.ko.Status.TransformJobStatus
+	if latestStatus != nil && *latestStatus != svcsdk.TransformJobStatusInProgress {
+		return nil
+	}


### PR DESCRIPTION
### Description of Changes
- Enable deletion of SageMaker job style CR from API server if the job is complete(i.e. JobStatus = `Completed`, `Failed`, `Stopped`)
- Reduce/clean up custom code by using callback hooks See: [Callback hooks PR](https://github.com/aws-controllers-k8s/code-generator/pull/26#issue-583144438), [Templates path PR](https://github.com/aws-controllers-k8s/code-generator/pull/28)
  - Now we no longer need to match the method signature of the parent operation for adding custom code unless we intend to use all the parameters.
- Address comment: https://github.com/aws-controllers-k8s/sagemaker-controller/pull/10#discussion_r615900444

### Testing
Tested manually - let the job(training, process, transform & hpo) run till completion and ensured running `kubectl delete` on the CR removes the resource from management. No error on controller side.

Without this PR, the controller gets stuck in backoff because of an error from SageMaker 
```
2021-03-25T07:41:11.356Z	DEBUG	ackrt	starting reconciliation	{"kind": "TrainingJob", "namespace": "default", "name": "xgboost-trainingjob-z61ptgyri5m1", "generation": 2, "account": "XXXX", "role": "", "region": "us-west-2"}
2021-03-25T07:41:11.707Z	ERROR	controller-runtime.controller	Reconciler error	{"controller": "trainingjob", "request": "default/xgboost-trainingjob-z61ptgyri5m1", "error": "ValidationException: The request was rejected because the training job is in status Completed.\n\tstatus code: 400, request id: 8e6a1690-9d35-4529-a2b9-3e9e011fcef2"}
github.com/go-logr/zapr.(*zapLogger).Error
	/home/ubuntu/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/home/ubuntu/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:258
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/home/ubuntu/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:232
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/home/ubuntu/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.6.0/pkg/internal/controller/controller.go:211
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
	/home/ubuntu/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:155
k8s.io/apimachinery/pkg/util/wait.BackoffUntil
	/home/ubuntu/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:156
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/home/ubuntu/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:133
k8s.io/apimachinery/pkg/util/wait.Until
	/home/ubuntu/go/pkg/mod/k8s.io/apimachinery@v0.18.6/pkg/util/wait/wait.go:90
```

automated tests will be part of a separate follow up of [@mbaijal's PR](https://github.com/aws-controllers-k8s/sagemaker-controller/pull/10)

### Related PRs
Both merged
[aws-controllers-k8s/code-generator#45](https://github.com/aws-controllers-k8s/code-generator/pull/45)
[aws-controllers-k8s/code-generator#26](https://github.com/aws-controllers-k8s/code-generator/pull/26)