### PR TITLE
endpoint resource: fix terminal condition showing up in recoverable

### DIFF
--- a/generator.yaml
+++ b/generator.yaml
@@ -84,6 +84,8 @@ resources:
         - MalformedQueryString
         - InvalidAction
         - UnrecognizedClientException
+        # Custom error
+        - EndpointUpdateError
     hooks:
       sdk_create_post_set_output:
         code: rm.customSetOutput(r, aws.String(svcsdk.EndpointStatusCreating), ko)

--- a/pkg/resource/endpoint/custom_set_output.go
+++ b/pkg/resource/endpoint/custom_set_output.go
@@ -85,14 +85,10 @@ func (rm *resourceManager) customSetOutput(
 	}
 
 	var resourceSyncedCondition *ackv1alpha1.Condition = nil
-	if ko.Status.Conditions == nil {
-		ko.Status.Conditions = []*ackv1alpha1.Condition{}
-	} else {
-		for _, condition := range ko.Status.Conditions {
-			if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
-				resourceSyncedCondition = condition
-				break
-			}
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
+			resourceSyncedCondition = condition
+			break
 		}
 	}
 

--- a/pkg/resource/endpoint/custom_update_api.go
+++ b/pkg/resource/endpoint/custom_update_api.go
@@ -19,16 +19,16 @@ package endpoint
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	"github.com/aws-controllers-k8s/runtime/pkg/requeue"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
 )
 
 var (
-	FailUpdateError = fmt.Errorf("Unable to update Endpoint. Check FailureReason")
+	FailUpdateError = awserr.New("EndpointUpdateError", "unable to update endpoint. check FailureReason", nil)
 
 	FailureReasonInternalServiceErrorPrefix = "Request to service failed"
 )

--- a/pkg/resource/endpoint/sdk.go
+++ b/pkg/resource/endpoint/sdk.go
@@ -444,7 +444,8 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 		"InvalidQueryParameter",
 		"MalformedQueryString",
 		"InvalidAction",
-		"UnrecognizedClientException":
+		"UnrecognizedClientException",
+		"EndpointUpdateError":
 		return true
 	default:
 		return false

--- a/pkg/resource/hyper_parameter_tuning_job/custom_set_output.go
+++ b/pkg/resource/hyper_parameter_tuning_job/custom_set_output.go
@@ -43,14 +43,10 @@ func (rm *resourceManager) customSetOutput(
 	}
 
 	var resourceSyncedCondition *ackv1alpha1.Condition = nil
-	if ko.Status.Conditions == nil {
-		ko.Status.Conditions = []*ackv1alpha1.Condition{}
-	} else {
-		for _, condition := range ko.Status.Conditions {
-			if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
-				resourceSyncedCondition = condition
-				break
-			}
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
+			resourceSyncedCondition = condition
+			break
 		}
 	}
 

--- a/pkg/resource/processing_job/custom_set_output.go
+++ b/pkg/resource/processing_job/custom_set_output.go
@@ -43,14 +43,10 @@ func (rm *resourceManager) customSetOutput(
 	}
 
 	var resourceSyncedCondition *ackv1alpha1.Condition = nil
-	if ko.Status.Conditions == nil {
-		ko.Status.Conditions = []*ackv1alpha1.Condition{}
-	} else {
-		for _, condition := range ko.Status.Conditions {
-			if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
-				resourceSyncedCondition = condition
-				break
-			}
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
+			resourceSyncedCondition = condition
+			break
 		}
 	}
 

--- a/pkg/resource/training_job/custom_set_output.go
+++ b/pkg/resource/training_job/custom_set_output.go
@@ -73,14 +73,10 @@ func (rm *resourceManager) customSetOutput(
 	}
 
 	var resourceSyncedCondition *ackv1alpha1.Condition = nil
-	if ko.Status.Conditions == nil {
-		ko.Status.Conditions = []*ackv1alpha1.Condition{}
-	} else {
-		for _, condition := range ko.Status.Conditions {
-			if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
-				resourceSyncedCondition = condition
-				break
-			}
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
+			resourceSyncedCondition = condition
+			break
 		}
 	}
 

--- a/pkg/resource/transform_job/custom_set_output.go
+++ b/pkg/resource/transform_job/custom_set_output.go
@@ -43,14 +43,10 @@ func (rm *resourceManager) customSetOutput(
 	}
 
 	var resourceSyncedCondition *ackv1alpha1.Condition = nil
-	if ko.Status.Conditions == nil {
-		ko.Status.Conditions = []*ackv1alpha1.Condition{}
-	} else {
-		for _, condition := range ko.Status.Conditions {
-			if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
-				resourceSyncedCondition = condition
-				break
-			}
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeResourceSynced {
+			resourceSyncedCondition = condition
+			break
 		}
 	}
 

--- a/test/e2e/tests/test_endpoint.py
+++ b/test/e2e/tests/test_endpoint.py
@@ -34,6 +34,8 @@ from e2e import (
 )
 from e2e.replacement_values import REPLACEMENT_VALUES
 
+FAIL_UPDATE_ERROR_MESSAGE = "unable to update endpoint. check FailureReason"
+
 
 @pytest.fixture(scope="module")
 def name_suffix():
@@ -286,7 +288,7 @@ class TestEndpoint:
             endpoint_reference,
             "ACK.Terminal",
             "True",
-            "Unable to update Endpoint. Check FailureReason",
+            FAIL_UPDATE_ERROR_MESSAGE,
         )
 
         endpoint_resource = k8s.get_resource(endpoint_reference)


### PR DESCRIPTION
### Description of Changes
- [aws-controllers-k8s/sagemaker-controller#7](https://github.com/aws-controllers-k8s/sagemaker-controller/pull/7) introduced ability to set terminal conditions for failed update scenarios by [returning an error](https://github.com/aws-controllers-k8s/sagemaker-controller/blob/main/pkg/resource/endpoint/custom_update_api.go#L85) (FailUpdateError) from [customUpdateEndpoint](https://github.com/aws-controllers-k8s/sagemaker-controller/blob/main/pkg/resource/endpoint/custom_update_api.go#L43-L85) method and [catching it in customUpdateConditions](https://github.com/aws-controllers-k8s/sagemaker-controller/blob/main/pkg/resource/endpoint/custom_update_conditions.go#L57)

- [aws-controllers-k8s/code-generator#40](https://github.com/aws-controllers-k8s/code-generator/pull/40) added a catch block for all errors which are non-terminal which executes before `customUpdateConditions`. Since `FailUpdateError` is a custom error, it started showing up in recoverable in addition to terminal condition once recoverable condition was introduced. Example:
```
"conditions": [
           ...
            {
                "message": "Unable to update Endpoint. Check FailureReason",
                "status": "True",
                "type": "ACK.Recoverable"
            },
            {
                "message": "Unable to update Endpoint. Check FailureReason",
                "status": "True",
                "type": "ACK.Terminal"
            }
        ],
```

This PR fixes this issue by creating making `FailUpdateError` an [awserr](https://github.com/aws/aws-sdk-go/blob/main/aws/awserr/error.go#L82) type of error and using it as one of the terminal codes just like any other AWS error. This also simplifies the custom code in customUpdateConditions which now only needs to check for `Status.EndpointStatus == Failed` while setting terminal condition

---

- Removes a redundant check for `if ko.Status.Conditions == nil` because all methods - [sdkCreate](https://github.com/aws-controllers-k8s/sagemaker-controller/blob/e3567fb9cf78dd916dca6c193bbb26cd27d8f98a/pkg/resource/endpoint/sdk.go#L157), [sdkFind](https://github.com/aws-controllers-k8s/sagemaker-controller/blob/e3567fb9cf78dd916dca6c193bbb26cd27d8f98a/pkg/resource/endpoint/sdk.go#L94), [sdkUdpate](https://github.com/aws-controllers-k8s/sagemaker-controller/blob/e3567fb9cf78dd916dca6c193bbb26cd27d8f98a/pkg/resource/endpoint/sdk.go#L235) and [updateConditions](https://github.com/aws-controllers-k8s/sagemaker-controller/blob/e3567fb9cf78dd916dca6c193bbb26cd27d8f98a/pkg/resource/endpoint/sdk.go#L319) - [set it to an empty list](https://github.com/aws-controllers-k8s/sagemaker-controller/blob/e3567fb9cf78dd916dca6c193bbb26cd27d8f98a/pkg/resource/endpoint/sdk.go#L307-L309) already

### Testing
Locally using pytest and manually
```
(ack) ubuntu@ip-172-31-0-119:~/go/src/github.com/aws-controllers-k8s/sagemaker-controller/test/e2e$ PYTHONPATH=. pytest -n 4 --dist loadfile
=============================================== test session starts ===============================================
platform linux -- Python 3.8.8, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/ubuntu/go/src/github.com/aws-controllers-k8s/sagemaker-controller/test/e2e
plugins: xdist-2.2.0, forked-1.3.0, black-0.3.12
gw0 [24] / gw1 [24] / gw2 [24] / gw3 [24]
........................                                                                                    [100%]
========================================= 24 passed in 1866.80s (0:31:06) =========================================
```