### PR TITLE
skip crd installation in helm

### DIFF
--- a/test/canary/scripts/install_controller_helm.sh
+++ b/test/canary/scripts/install_controller_helm.sh
@@ -13,5 +13,6 @@ function install_helm_chart() {
     yq w -i helm/values.yaml "aws.region" $region
 
     kubectl create namespace $namespace
-    helm install -n $namespace ack-$service-controller helm
+    kubectl apply -f helm/crds
+    helm install -n $namespace ack-$service-controller --skip-crds helm
 }

--- a/test/canary/scripts/run_test.sh
+++ b/test/canary/scripts/run_test.sh
@@ -47,7 +47,9 @@ function cleanup {
   print_controller_logs
 
   helm delete -n $NAMESPACE ack-$SERVICE-controller
-  kubectl delete -f helm/crds
+  pushd $SERVICE_REPO_PATH
+    kubectl delete -f helm/crds
+  popd
   kubectl delete namespace $NAMESPACE
 
   cd $E2E_DIR

--- a/test/canary/scripts/run_test.sh
+++ b/test/canary/scripts/run_test.sh
@@ -47,6 +47,7 @@ function cleanup {
   print_controller_logs
 
   helm delete -n $NAMESPACE ack-$SERVICE-controller
+  kubectl delete -f helm/crds
   kubectl delete namespace $NAMESPACE
 
   cd $E2E_DIR

--- a/test/canary/scripts/setup_oidc.sh
+++ b/test/canary/scripts/setup_oidc.sh
@@ -4,8 +4,8 @@
 # A function to get the OIDC_ID associated with an EKS cluster
 function get_oidc_id() {
   local cluster_name="$1"
-  local region = "$2"
-  eksctl utils associate-iam-oidc-provider --cluster $cluster_name --region $region --approve
+  local region="$2"
+  eksctl utils associate-iam-oidc-provider --cluster $cluster_name --region $region --approve > /dev/null
   local oidc_url=$(aws eks describe-cluster --region $region --name $cluster_name  --query "cluster.identity.oidc.issuer" --output text | cut -c9-)
   echo "${oidc_url}"
 }


### PR DESCRIPTION
- install/uninstall crds separately since helm uninstall does not delete crds 
  - there are GitHub issues indicating its meant to be managed separately
- bug fixes to canary scripts

### Testing
using codebuild