### PR TITLE
Update `generator.yaml` print configurations

### DIFF
--- a/generator.yaml
+++ b/generator.yaml
@@ -95,13 +95,16 @@ resources:
     fields:
       EndpointStatus:
         is_read_only: true
-        is_printable: true
+        print:
+          name: STATUS
         from:
           operation: DescribeEndpoint
           path: EndpointStatus
       FailureReason:
         is_read_only: true
-        is_printable: true
+        print:
+          name: FAILURE-REASON
+          priority: 1
         from:
           operation: DescribeEndpoint
           path: FailureReason
@@ -159,14 +162,16 @@ resources:
         template_path: training_job/sdk_delete_pre_build_request.go.tpl
     fields:
       TrainingJobStatus:
-          is_read_only: true
-          is_printable: true
-          from:
-            operation: DescribeTrainingJob
-            path: TrainingJobStatus
+        is_read_only: true
+        print:
+          name: STATUS
+        from:
+          operation: DescribeTrainingJob
+          path: TrainingJobStatus
       SecondaryStatus:
         is_read_only: true
-        is_printable: true
+        print:
+          name: SECONDARY-STATUS
         from:
           operation: DescribeTrainingJob
           path: SecondaryStatus
@@ -177,7 +182,9 @@ resources:
           path: DebugRuleEvaluationStatuses 
       FailureReason:
         is_read_only: true
-        is_printable: true
+        print:
+          name: FAILURE-REASON
+          priority: 1
         from:
           operation: DescribeTrainingJob
           path: FailureReason 
@@ -213,13 +220,16 @@ resources:
     fields:
       ProcessingJobStatus:
         is_read_only: true
-        is_printable: true
+        print:
+          name: STATUS
         from:
           operation: DescribeProcessingJob
           path: ProcessingJobStatus
       FailureReason:
         is_read_only: true
-        is_printable: true
+        print:
+          name: FAILURE-REASON
+          priority: 1
         from:
           operation: DescribeProcessingJob
           path: FailureReason 
@@ -254,14 +264,17 @@ resources:
         code: rm.customSetOutput(r, resp.TransformJobStatus, ko)
     fields:
       TransformJobStatus:
-          is_read_only: true
-          is_printable: true
-          from:
-            operation: DescribeTransformJob
-            path: TransformJobStatus
+        is_read_only: true
+        print:
+          name: STATUS
+        from:
+          operation: DescribeTransformJob
+          path: TransformJobStatus
       FailureReason:
         is_read_only: true
-        is_printable: true
+        print:
+          name: FAILURE-REASON
+          priority: 1
         from:
           operation: DescribeTransformJob
           path: FailureReason
@@ -296,13 +309,16 @@ resources:
     fields:
       HyperParameterTuningJobStatus:
         is_read_only: true
-        is_printable: true
+        print:
+          name: STATUS
         from:
           operation: DescribeHyperParameterTuningJob
           path: HyperParameterTuningJobStatus
       FailureReason:
         is_read_only: true
-        is_printable: true
+        print:
+          name: FAILURE-REASON
+          priority: 1
         from:
           operation: DescribeHyperParameterTuningJob
           path: FailureReason
@@ -441,13 +457,16 @@ resources:
     fields:
       MonitoringScheduleStatus:
         is_read_only: true
-        is_printable: true
+        print:
+          name: STATUS
         from:
           operation: DescribeMonitoringSchedule
           path: MonitoringScheduleStatus
       FailureReason:
         is_read_only: true
-        is_printable: true
+        print:
+          name: FAILURE-REASON
+          priority: 1
         from:
           operation: DescribeMonitoringSchedule
           path: FailureReason


### PR DESCRIPTION
Issue N/A

Recently we merged a PR that changed `is_printable` field types to
structs, mainly to allow users to set other printing parameters: like
type, priority and order.

Ref: https://github.com/aws-controllers-k8s/code-generator/pull/82