### PR TITLE
Create Failed terminal condition Feature Group Creating requeue 

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2021-07-22T20:36:39Z"
+  build_date: "2021-07-23T02:02:51Z"
   build_hash: 6911f924191f5315747c8e81fbcbf29b4edc8cb1
   go_version: go1.16.4 linux/amd64
   version: v0.3.1
@@ -7,8 +7,8 @@ api_directory_checksum: 4906740ff8ff6ebfffbaea971f7e8aa5a858edd8
 api_version: v1alpha1
 aws_sdk_go_version: v1.38.11
 generator_config_info:
-  file_checksum: c05fa636159c1f79ab353fd790587a5b36f8b95b
+  file_checksum: 8e1b7e085d2ff8673e0d239e05e0a1403825c355
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-07-22 20:36:41.771709478 +0000 UTC
+  timestamp: 2021-07-23 02:02:53.613950676 +0000 UTC

--- a/generator.yaml
+++ b/generator.yaml
@@ -69,7 +69,7 @@ resources:
   Endpoint:
     reconcile: 
       requeue_on_success_seconds: 30
-    update_conditions_custom_method_name: customUpdateConditions
+    update_conditions_custom_method_name: CustomUpdateConditions
     exceptions:
       errors:
         404:
@@ -429,7 +429,7 @@ resources:
   MonitoringSchedule:
     reconcile: 
       requeue_on_success_seconds: 30
-    update_conditions_custom_method_name: customUpdateConditions
+    update_conditions_custom_method_name: CustomUpdateConditions
     exceptions:
       errors:
           404:
@@ -490,6 +490,7 @@ resources:
           operation: DescribeMonitoringSchedule
           path: LastMonitoringExecutionSummary
   FeatureGroup:
+    update_conditions_custom_method_name: CustomUpdateConditions
     exceptions:
       errors:
           404:
@@ -514,6 +515,8 @@ resources:
         template_path: common/sdk_delete_pre_build_request.go.tpl
       sdk_delete_post_request:
         template_path: common/sdk_delete_post_request.go.tpl
+      sdk_read_one_post_set_output:
+        code: rm.customSetOutput(&resource{ko})
     fields:
       FailureReason:
         is_read_only: true

--- a/pkg/common/custom_conditions.go
+++ b/pkg/common/custom_conditions.go
@@ -1,0 +1,74 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Use this file if conditions need to be updated based on the latest status
+// of endpoint which is not evident from API response
+
+package common
+
+import (
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// SetSyncedCondition sets the ACK Synced Condition
+// status to true if the resource status exists but
+// is not in one of the given modifying statuses,
+// or false if the resource status is one of the
+// given modifying statuses.
+func SetSyncedCondition(
+	r acktypes.AWSResource,
+	latestStatus *string,
+	resourceName *string,
+	modifyingStatuses *[]string,
+) {
+	if latestStatus == nil {
+		return
+	}
+
+	msg := *resourceName + " is in " + *latestStatus + " status."
+	conditionStatus := corev1.ConditionTrue
+	if IsModifyingStatus(latestStatus, modifyingStatuses) {
+		conditionStatus = corev1.ConditionFalse
+	}
+
+	ackcondition.SetSynced(r, conditionStatus, &msg, nil)
+}
+
+// SetTerminalState sets conditions (terminal) on
+// a resource's supplied status conditions if the
+// latest status matches the terminal status.
+// It returns true if conditions are updated.
+func SetTerminalState(
+	r acktypes.AWSResource,
+	latestStatus *string,
+	resourceName *string,
+	terminalStatus string,
+) bool {
+	if latestStatus == nil || *latestStatus != terminalStatus {
+		return false
+	}
+
+	terminalCondition := ackcondition.Terminal(r)
+	if terminalCondition != nil && terminalCondition.Status == corev1.ConditionTrue {
+		// some other exception already put the resource in terminal condition
+		return false
+	}
+
+	// setting terminal condition since controller can no longer recover by retrying
+	terminalMessage := *resourceName + " status reached terminal state: " + terminalStatus + ". Check the FailureReason."
+	ackcondition.SetTerminal(r, corev1.ConditionTrue, &terminalMessage, nil)
+
+	return true
+}

--- a/pkg/resource/endpoint/custom_update_conditions.go
+++ b/pkg/resource/endpoint/custom_update_conditions.go
@@ -17,48 +17,24 @@
 package endpoint
 
 import (
-	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	svcapitypes "github.com/aws-controllers-k8s/sagemaker-controller/apis/v1alpha1"
-	"github.com/aws/aws-sdk-go/aws"
+	svccommon "github.com/aws-controllers-k8s/sagemaker-controller/pkg/common"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	corev1 "k8s.io/api/core/v1"
 )
 
-// CustomUpdateConditions sets conditions (terminal) on supplied endpoint
+// CustomUpdateConditions sets conditions (terminal) on supplied endpoint.
 // it examines supplied resource to determine conditions.
-// It returns true if conditions are updated
-func (rm *resourceManager) customUpdateConditions(
+// It returns true if conditions are updated.
+func (rm *resourceManager) CustomUpdateConditions(
 	ko *svcapitypes.Endpoint,
 	r *resource,
 	err error,
 ) bool {
 	latestStatus := r.ko.Status.EndpointStatus
-
-	if latestStatus == nil || *latestStatus != svcsdk.EndpointStatusFailed {
-		return false
-	}
-	var terminalCondition *ackv1alpha1.Condition = nil
-
-	for _, condition := range ko.Status.Conditions {
-		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
-			terminalCondition = condition
-			break
-		}
-	}
-	if terminalCondition != nil && terminalCondition.Status == corev1.ConditionTrue {
-		// some other exception already put the resource in terminal condition
-		return false
-	}
-
-	// setting terminal condition since controller can no longer recover by retrying
-	if terminalCondition == nil {
-		terminalCondition = &ackv1alpha1.Condition{
-			Type: ackv1alpha1.ConditionTypeTerminal,
-		}
-		ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
-	}
-	terminalCondition.Status = corev1.ConditionTrue
-	terminalCondition.Message = aws.String("endpoint status: Failed. check FailureReason")
-
-	return true
+	terminalStatus := svcsdk.EndpointStatusFailed
+	conditionManager := &resource{ko}
+	resourceName := resourceGK.Kind
+	// If the latestStatus == terminalStatus we will set
+	// the terminal condition and terminal message.
+	return svccommon.SetTerminalState(conditionManager, latestStatus, &resourceName, terminalStatus)
 }

--- a/pkg/resource/endpoint/sdk.go
+++ b/pkg/resource/endpoint/sdk.go
@@ -434,7 +434,7 @@ func (rm *resourceManager) updateConditions(
 		ko.Status.Conditions = append(ko.Status.Conditions, syncCondition)
 	}
 	// custom update conditions
-	customUpdate := rm.customUpdateConditions(ko, r, err)
+	customUpdate := rm.CustomUpdateConditions(ko, r, err)
 	if terminalCondition != nil || recoverableCondition != nil || syncCondition != nil || customUpdate {
 		return &resource{ko}, true // updated
 	}

--- a/pkg/resource/feature_group/custom_update_conditions.go
+++ b/pkg/resource/feature_group/custom_update_conditions.go
@@ -11,10 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-// Use this file if conditions need to be updated based on the latest status
-// of resource which is not evident from API response
-
-package monitoring_schedule
+package feature_group
 
 import (
 	svcapitypes "github.com/aws-controllers-k8s/sagemaker-controller/apis/v1alpha1"
@@ -22,18 +19,17 @@ import (
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
 )
 
-// CustomUpdateConditions sets conditions (terminal) on supplied monitoring schedule.
+// CustomUpdateConditions sets conditions (terminal) on supplied feature group.
 // it examines supplied resource to determine conditions.
 // It returns true if conditions are updated.
 func (rm *resourceManager) CustomUpdateConditions(
-	ko *svcapitypes.MonitoringSchedule,
+	ko *svcapitypes.FeatureGroup,
 	r *resource,
 	err error,
 ) bool {
-	latestStatus := r.ko.Status.MonitoringScheduleStatus
-	terminalStatus := svcsdk.ScheduleStatusFailed
+	latestStatus := r.ko.Status.FeatureGroupStatus
+	terminalStatus := svcsdk.FeatureGroupStatusCreateFailed
 	conditionManager := &resource{ko}
-	resourceName := resourceGK.Kind
 	// If the latestStatus == terminalStatus we will set
 	// the terminal condition and terminal message.
 	return svccommon.SetTerminalState(conditionManager, latestStatus, &resourceName, terminalStatus)

--- a/pkg/resource/feature_group/hooks.go
+++ b/pkg/resource/feature_group/hooks.go
@@ -43,3 +43,11 @@ func (rm *resourceManager) requeueUntilCanModify(
 	latestStatus := r.ko.Status.FeatureGroupStatus
 	return svccommon.RequeueIfModifying(latestStatus, &resourceName, &modifyingStatuses)
 }
+
+// customSetOutput sets the ack syncedCondition depending on
+// whether the latest status of the resource is one of the
+// defined modifyingStatuses.
+func (rm *resourceManager) customSetOutput(r *resource) {
+	latestStatus := r.ko.Status.FeatureGroupStatus
+	svccommon.SetSyncedCondition(r, latestStatus, &resourceName, &modifyingStatuses)
+}

--- a/pkg/resource/feature_group/sdk.go
+++ b/pkg/resource/feature_group/sdk.go
@@ -187,6 +187,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	rm.customSetOutput(&resource{ko})
 	return &resource{ko}, nil
 }
 
@@ -479,7 +480,9 @@ func (rm *resourceManager) updateConditions(
 	}
 	// Required to avoid the "declared but not used" error in the default case
 	_ = syncCondition
-	if terminalCondition != nil || recoverableCondition != nil || syncCondition != nil {
+	// custom update conditions
+	customUpdate := rm.CustomUpdateConditions(ko, r, err)
+	if terminalCondition != nil || recoverableCondition != nil || syncCondition != nil || customUpdate {
 		return &resource{ko}, true // updated
 	}
 	return nil, false // not updated

--- a/pkg/resource/model_package_group/hooks.go
+++ b/pkg/resource/model_package_group/hooks.go
@@ -17,11 +17,9 @@ import (
 	"context"
 	"errors"
 
-	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	svccommon "github.com/aws-controllers-k8s/sagemaker-controller/pkg/common"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	corev1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -38,16 +36,8 @@ var (
 )
 
 func (rm *resourceManager) customSetOutput(r *resource) {
-	if r.ko.Status.ModelPackageGroupStatus == nil {
-		return
-	}
-	ModelPackageGroupStatus := *r.ko.Status.ModelPackageGroupStatus
-	msg := "ModelPackageGroup is in" + ModelPackageGroupStatus + "status"
-	if !svccommon.IsModifyingStatus(&ModelPackageGroupStatus, &modifyingStatuses) {
-		ackcondition.SetSynced(r, corev1.ConditionTrue, &msg, nil)
-	} else {
-		ackcondition.SetSynced(r, corev1.ConditionFalse, &msg, nil)
-	}
+	latestStatus := r.ko.Status.ModelPackageGroupStatus
+	svccommon.SetSyncedCondition(r, latestStatus, &resourceName, &modifyingStatuses)
 }
 
 // requeueUntilCanModify creates and returns an

--- a/pkg/resource/monitoring_schedule/sdk.go
+++ b/pkg/resource/monitoring_schedule/sdk.go
@@ -1055,7 +1055,7 @@ func (rm *resourceManager) updateConditions(
 		ko.Status.Conditions = append(ko.Status.Conditions, syncCondition)
 	}
 	// custom update conditions
-	customUpdate := rm.customUpdateConditions(ko, r, err)
+	customUpdate := rm.CustomUpdateConditions(ko, r, err)
 	if terminalCondition != nil || recoverableCondition != nil || syncCondition != nil || customUpdate {
 		return &resource{ko}, true // updated
 	}

--- a/test/e2e/tests/test_feature_group.py
+++ b/test/e2e/tests/test_feature_group.py
@@ -33,11 +33,14 @@ from e2e.replacement_values import REPLACEMENT_VALUES
 RESOURCE_NAME_PREFIX = "feature-group"
 RESOURCE_PLURAL = "featuregroups"
 SPEC_FILE = "feature_group"
-FEATURE_GROUP_STATUS_CREATED = "CREATED"
+FEATURE_GROUP_STATUS_CREATING = "Creating"
+FEATURE_GROUP_STATUS_CREATED = "Created"
 WAIT_PERIOD_COUNT = 3
 # A 15 second wait period is used because we sometimes see
 # time out errors at a 10 second wait period.
 WAIT_PERIOD_LENGTH = 15
+STATUS = "status"
+RESOURCE_STATUS = "featureGroupStatus"
 
 @pytest.fixture(scope="module")
 def feature_group():
@@ -73,6 +76,11 @@ def get_feature_group_status(feature_group_name: str):
     feature_group_describe_response = get_sagemaker_feature_group(feature_group_name)
     return feature_group_describe_response["FeatureGroupStatus"]
 
+def get_resource_feature_group_status(reference: k8s.CustomResourceReference):
+    resource = k8s.get_resource(reference)
+    assert RESOURCE_STATUS in resource[STATUS]
+    return resource[STATUS][RESOURCE_STATUS]
+
 @service_marker
 @pytest.mark.canary
 class TestFeatureGroup:
@@ -90,6 +98,30 @@ class TestFeatureGroup:
             get_feature_group_status,
             feature_group_name,
         )
+
+    def _wait_resource_feature_group_status(
+            self,
+            reference: k8s.CustomResourceReference,
+            expected_status: str,
+            wait_periods: int = WAIT_PERIOD_COUNT,
+            period_length: int = WAIT_PERIOD_LENGTH,
+    ):
+        return wait_for_status(
+            expected_status,
+            wait_periods,
+            period_length,
+            get_resource_feature_group_status,
+            reference,
+        )
+
+    def _assert_feature_group_status_in_sync(
+            self, feature_group_name, reference, expected_status
+    ):
+        assert (
+            self._wait_feature_group_status(feature_group_name, expected_status)
+            == self._wait_resource_feature_group_status(reference, expected_status)
+            == expected_status
+        )
     
     def test_create_feature_group(self, feature_group):
         """Tests that a feature group can be created and deleted
@@ -99,6 +131,7 @@ class TestFeatureGroup:
         assert k8s.get_resource_exists(reference)
         
         feature_group_name = resource["spec"].get("featureGroupName", None)
+        assert feature_group_name is not None
         
         feature_group_describe_response = get_sagemaker_feature_group(feature_group_name)
         
@@ -106,14 +139,17 @@ class TestFeatureGroup:
             k8s.get_resource_arn(resource)
             == feature_group_describe_response["FeatureGroupArn"]
         )
-        
-        assert (
-            self._wait_feature_group_status(
-                feature_group_name, FEATURE_GROUP_STATUS_CREATED
-            )
+
+        assert feature_group_describe_response["FeatureGroupStatus"] == FEATURE_GROUP_STATUS_CREATING
+
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "False")
+
+        self._assert_feature_group_status_in_sync(
+            feature_group_name, reference, FEATURE_GROUP_STATUS_CREATED
         )
-        # TODO: add resource side checks.
-        
+
+        assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True")
+
         # Delete the k8s resource.
         _, deleted = k8s.delete_custom_resource(reference, WAIT_PERIOD_COUNT, WAIT_PERIOD_LENGTH)
         assert deleted


### PR DESCRIPTION
Summary:
Set terminal condition for feature group in "Create Failed" state. Also factored out common custom_update_conditions code between feature group, monitoring schedule, and endpoint. Secondly, added requeue on Creating functionality for feature group in order to allow for the feature group status to be updated to Created.

Files Added:
- pkg/common/custom_set_terminal_state.go - Contains functionality of custom_update_conditions.go from previous endpoint / monitoring files (that is also reused with feature group).
- pkg/common/custom_set_synced_condition.go - Contains general functionality of customSetOutput from previous model package group hooks.go (that is also reused with feature group).
- pkg/common/custom_utilities.go - Contains helper function IsModifyingStatus that is used for both this PR and [PR #52](https://github.com/aws-controllers-k8s/sagemaker-controller/pull/52). Derived from previous model package group hooks.go.
- pkg/resource/feature_group/custom_update_conditions.go - added call to custom_set_terminal_state.go to set the terminal condition if the feature group "Create Failed" state is reached.
- pkg/resource/feature_group/hooks.go - Contains helper function isCreating, and ackrequeue variable requeueWaitWhileCreating which are referenced from (also new) resource manager customSetOutput function that is called post read One.

Files Edited:
- generator.yaml - Added custom update for featuregroup and updated captalization for custom update functions for endpoint and monitoring schedule to be consistent. Also included sdk_read_one_post_set_output hook calling to customSetOutput function.
- pkg/resource/endpoint/custom_update_conditions.go - factored out common code into custom_set_terminal_state.go
- pkg/resource/monitoring_schedule/custom_update_conditions.go - factored out common code into custom_set_terminal_state.go. Also replaced hardcoded string with library defined reference.
- pkg/resource/model_package_group/hooks.go - factored out common code into custom_set_synced_condition.go.