### PR TITLE
Add primary identifier fields for job definitions

### DIFF
--- a/generator.yaml
+++ b/generator.yaml
@@ -22,6 +22,14 @@ operations:
   StopHyperParameterTuningJob:
     operation_type: Delete
     resource_name: HyperParameterTuningJob
+  DescribeModelBiasJobDefinition:
+    primary_identifier_field_name: JobDefinitionName
+  DescribeModelExplainabilityJobDefinition:
+    primary_identifier_field_name: JobDefinitionName
+  DescribeModelQualityJobDefinition:
+    primary_identifier_field_name: JobDefinitionName
+  DescribeDataQualityJobDefinition:
+    primary_identifier_field_name: JobDefinitionName
 resources:
   Model:
     exceptions:


### PR DESCRIPTION
Adds the `primary_identifier_field_name` field in the generator for the `ModelBias`, `ModelExplainability`, `ModelQuality` and `DataQuality` job definition types.