### PR TITLE
Temp remove flaky test

### DIFF
--- a/test/e2e/tests/test_adopt_endpoint.py
+++ b/test/e2e/tests/test_adopt_endpoint.py
@@ -171,7 +171,6 @@ def adopted_endpoint(sdk_endpoint):
 
 
 @service_marker
-@pytest.mark.canary
 class TestAdoptedEndpoint:
     def test_smoke(self, sdk_endpoint, adopted_endpoint):
         (


### PR DESCRIPTION
Disable this canary test as it is currently flaky and is under investigation. Also allows us to observe the effects of the reduction of flaky tests that were not test adopt endpoint in Canary accounts 