### PR TITLE
release artifacts for release v0.0.2

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-name: ack-sagemaker-controller
+name: sagemaker-chart
 description: A Helm chart for the ACK service controller for sagemaker
-version: v0.0.1
-appVersion: v0.0.1
+version: v0.0.2
+appVersion: v0.0.2
 home: https://github.com/aws-controllers-k8s/sagemaker-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/crds/sagemaker.services.k8s.aws_dataqualityjobdefinitions.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_dataqualityjobdefinitions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: dataqualityjobdefinitions.sagemaker.services.k8s.aws
 spec:
@@ -36,7 +36,7 @@ spec:
             type: object
           spec:
             description: DataQualityJobDefinitionSpec defines the desired state of
-              DataQualityJobDefinition
+              DataQualityJobDefinition.
             properties:
               dataQualityAppSpecification:
                 description: Specifies the container that runs the monitoring job.
@@ -192,6 +192,19 @@ spec:
                     format: int64
                     type: integer
                 type: object
+              tags:
+                description: (Optional) An array of key-value pairs. For more information,
+                  see Using Cost Allocation Tags (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html#allocation-whatURL)
+                  in the AWS Billing and Cost Management User Guide.
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
             required:
             - dataQualityAppSpecification
             - dataQualityJobInput

--- a/helm/crds/sagemaker.services.k8s.aws_endpointconfigs.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_endpointconfigs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: endpointconfigs.sagemaker.services.k8s.aws
 spec:
@@ -34,7 +34,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: EndpointConfigSpec defines the desired state of EndpointConfig
+            description: EndpointConfigSpec defines the desired state of EndpointConfig.
             properties:
               dataCaptureConfig:
                 properties:
@@ -124,6 +124,20 @@ spec:
                     modelName:
                       type: string
                     variantName:
+                      type: string
+                  type: object
+                type: array
+              tags:
+                description: An array of key-value pairs. You can use tags to categorize
+                  your AWS resources in different ways, for example, by purpose, owner,
+                  or environment. For more information, see Tagging AWS Resources
+                  (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html).
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
                       type: string
                   type: object
                 type: array

--- a/helm/crds/sagemaker.services.k8s.aws_endpoints.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_endpoints.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: endpoints.sagemaker.services.k8s.aws
 spec:
@@ -17,11 +17,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.endpointStatus
-      name: EndpointStatus
-      type: string
     - jsonPath: .status.failureReason
-      name: FailureReason
+      name: FAILURE-REASON
+      priority: 1
+      type: string
+    - jsonPath: .status.endpointStatus
+      name: STATUS
       type: string
     name: v1alpha1
     schema:
@@ -41,7 +42,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: EndpointSpec defines the desired state of Endpoint
+            description: "EndpointSpec defines the desired state of Endpoint. \n A
+              hosted endpoint for real-time inference."
             properties:
               endpointConfigName:
                 description: The name of an endpoint configuration. For more information,
@@ -53,6 +55,20 @@ spec:
                   in CreateEndpoint, but the case is preserved and must be matched
                   in .
                 type: string
+              tags:
+                description: An array of key-value pairs. You can use tags to categorize
+                  your AWS resources in different ways, for example, by purpose, owner,
+                  or environment. For more information, see Tagging AWS Resources
+                  (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html).
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
             required:
             - endpointConfigName
             - endpointName

--- a/helm/crds/sagemaker.services.k8s.aws_featuregroups.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_featuregroups.yaml
@@ -1,0 +1,254 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: featuregroups.sagemaker.services.k8s.aws
+spec:
+  group: sagemaker.services.k8s.aws
+  names:
+    kind: FeatureGroup
+    listKind: FeatureGroupList
+    plural: featuregroups
+    singular: featuregroup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.failureReason
+      name: FAILURE-REASON
+      priority: 1
+      type: string
+    - jsonPath: .status.featureGroupStatus
+      name: STATUS
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: FeatureGroup is the Schema for the FeatureGroups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: "FeatureGroupSpec defines the desired state of FeatureGroup.
+              \n Amazon SageMaker Feature Store stores features in a collection called
+              Feature Group. A Feature Group can be visualized as a table which has
+              rows, with a unique identifier for each row where each column in the
+              table is a feature. In principle, a Feature Group is composed of features
+              and values per features."
+            properties:
+              description:
+                description: A free-form description of a FeatureGroup.
+                type: string
+              eventTimeFeatureName:
+                description: "The name of the feature that stores the EventTime of
+                  a Record in a FeatureGroup. \n An EventTime is a point in time when
+                  a new event occurs that corresponds to the creation or update of
+                  a Record in a FeatureGroup. All Records in the FeatureGroup must
+                  have a corresponding EventTime. \n An EventTime can be a String
+                  or Fractional. \n    * Fractional: EventTime feature values must
+                  be a Unix timestamp in seconds. \n    * String: EventTime feature
+                  values must be an ISO-8601 string in the format.    The following
+                  formats are supported yyyy-MM-dd'T'HH:mm:ssZ and yyyy-MM-dd'T'HH:mm:ss.SSSZ
+                  \   where yyyy, MM, and dd represent the year, month, and day respectively
+                  \   and HH, mm, ss, and if applicable, SSS represent the hour, month,
+                  second    and milliseconds respsectively. 'T' and Z are constants."
+                type: string
+              featureDefinitions:
+                description: "A list of Feature names and types. Name and Type is
+                  compulsory per Feature. \n Valid feature FeatureTypes are Integral,
+                  Fractional and String. \n FeatureNames cannot be any of the following:
+                  is_deleted, write_time, api_invocation_time \n You can create up
+                  to 2,500 FeatureDefinitions per FeatureGroup."
+                items:
+                  description: A list of features. You must include FeatureName and
+                    FeatureType. Valid feature FeatureTypes are Integral, Fractional
+                    and String.
+                  properties:
+                    featureName:
+                      type: string
+                    featureType:
+                      type: string
+                  type: object
+                type: array
+              featureGroupName:
+                description: "The name of the FeatureGroup. The name must be unique
+                  within an AWS Region in an AWS account. The name: \n    * Must start
+                  and end with an alphanumeric character. \n    * Can only contain
+                  alphanumeric character and hyphens. Spaces are not    allowed."
+                type: string
+              offlineStoreConfig:
+                description: "Use this to configure an OfflineFeatureStore. This parameter
+                  allows you to specify: \n    * The Amazon Simple Storage Service
+                  (Amazon S3) location of an OfflineStore. \n    * A configuration
+                  for an AWS Glue or AWS Hive data cataolgue. \n    * An KMS encryption
+                  key to encrypt the Amazon S3 location used for OfflineStore. \n
+                  To learn more about this parameter, see OfflineStoreConfig."
+                properties:
+                  dataCatalogConfig:
+                    description: The meta data of the Glue table which serves as data
+                      catalog for the OfflineStore.
+                    properties:
+                      catalog:
+                        type: string
+                      database:
+                        type: string
+                      tableName:
+                        type: string
+                    type: object
+                  disableGlueTableCreation:
+                    type: boolean
+                  s3StorageConfig:
+                    description: The Amazon Simple Storage (Amazon S3) location and
+                      and security configuration for OfflineStore.
+                    properties:
+                      kmsKeyID:
+                        type: string
+                      resolvedOutputS3URI:
+                        type: string
+                      s3URI:
+                        type: string
+                    type: object
+                type: object
+              onlineStoreConfig:
+                description: "You can turn the OnlineStore on or off by specifying
+                  True for the EnableOnlineStore flag in OnlineStoreConfig; the default
+                  value is False. \n You can also include an AWS KMS key ID (KMSKeyId)
+                  for at-rest encryption of the OnlineStore."
+                properties:
+                  enableOnlineStore:
+                    type: boolean
+                  securityConfig:
+                    description: The security configuration for OnlineStore.
+                    properties:
+                      kmsKeyID:
+                        type: string
+                    type: object
+                type: object
+              recordIdentifierFeatureName:
+                description: "The name of the Feature whose value uniquely identifies
+                  a Record defined in the FeatureStore. Only the latest record per
+                  identifier value will be stored in the OnlineStore. RecordIdentifierFeatureName
+                  must be one of feature definitions' names. \n You use the RecordIdentifierFeatureName
+                  to access data in a FeatureStore. \n This name: \n    * Must start
+                  and end with an alphanumeric character. \n    * Can only contains
+                  alphanumeric characters, hyphens, underscores. Spaces    are not
+                  allowed."
+                type: string
+              roleARN:
+                description: The Amazon Resource Name (ARN) of the IAM execution role
+                  used to persist data into the OfflineStore if an OfflineStoreConfig
+                  is provided.
+                type: string
+              tags:
+                description: Tags used to identify Features in each FeatureGroup.
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+            required:
+            - eventTimeFeatureName
+            - featureDefinitions
+            - featureGroupName
+            - recordIdentifierFeatureName
+            type: object
+          status:
+            description: FeatureGroupStatus defines the observed state of FeatureGroup
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureReason:
+                description: "The reason that the FeatureGroup failed to be replicated
+                  in the OfflineStore. This is failure can occur because: \n    *
+                  The FeatureGroup could not be created in the OfflineStore. \n    *
+                  The FeatureGroup could not be deleted from the OfflineStore."
+                type: string
+              featureGroupStatus:
+                description: The status of the feature group.
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/helm/crds/sagemaker.services.k8s.aws_hyperparametertuningjobs.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_hyperparametertuningjobs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: hyperparametertuningjobs.sagemaker.services.k8s.aws
 spec:
@@ -18,10 +18,11 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.failureReason
-      name: FailureReason
+      name: FAILURE-REASON
+      priority: 1
       type: string
     - jsonPath: .status.hyperParameterTuningJobStatus
-      name: HyperParameterTuningJobStatus
+      name: STATUS
       type: string
     name: v1alpha1
     schema:
@@ -43,7 +44,7 @@ spec:
             type: object
           spec:
             description: HyperParameterTuningJobSpec defines the desired state of
-              HyperParameterTuningJob
+              HyperParameterTuningJob.
             properties:
               hyperParameterTuningJobConfig:
                 description: The HyperParameterTuningJobConfig object that describes
@@ -150,6 +151,22 @@ spec:
                   The name must have 1 to 32 characters. Valid characters are a-z,
                   A-Z, 0-9, and : + = @ _ % - (hyphen). The name is not case sensitive.'
                 type: string
+              tags:
+                description: "An array of key-value pairs. You can use tags to categorize
+                  your AWS resources in different ways, for example, by purpose, owner,
+                  or environment. For more information, see Tagging AWS Resources
+                  (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html).
+                  \n Tags that you specify for the tuning job are also added to all
+                  training jobs that the tuning job launches."
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
               trainingJobDefinition:
                 description: The HyperParameterTrainingJobDefinition object that describes
                   the training jobs that this tuning job launches, including static

--- a/helm/crds/sagemaker.services.k8s.aws_modelbiasjobdefinitions.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_modelbiasjobdefinitions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: modelbiasjobdefinitions.sagemaker.services.k8s.aws
 spec:
@@ -35,7 +35,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: ModelBiasJobDefinitionSpec defines the desired state of ModelBiasJobDefinition
+            description: ModelBiasJobDefinitionSpec defines the desired state of ModelBiasJobDefinition.
             properties:
               jobDefinitionName:
                 description: The name of the bias job definition. The name must be
@@ -181,6 +181,19 @@ spec:
                     format: int64
                     type: integer
                 type: object
+              tags:
+                description: (Optional) An array of key-value pairs. For more information,
+                  see Using Cost Allocation Tags (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html#allocation-whatURL)
+                  in the AWS Billing and Cost Management User Guide.
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
             required:
             - jobDefinitionName
             - jobResources

--- a/helm/crds/sagemaker.services.k8s.aws_modelexplainabilityjobdefinitions.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_modelexplainabilityjobdefinitions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: modelexplainabilityjobdefinitions.sagemaker.services.k8s.aws
 spec:
@@ -36,7 +36,7 @@ spec:
             type: object
           spec:
             description: ModelExplainabilityJobDefinitionSpec defines the desired
-              state of ModelExplainabilityJobDefinition
+              state of ModelExplainabilityJobDefinition.
             properties:
               jobDefinitionName:
                 description: The name of the model explainability job definition.
@@ -176,6 +176,19 @@ spec:
                     format: int64
                     type: integer
                 type: object
+              tags:
+                description: (Optional) An array of key-value pairs. For more information,
+                  see Using Cost Allocation Tags (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html#allocation-whatURL)
+                  in the AWS Billing and Cost Management User Guide.
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
             required:
             - jobDefinitionName
             - jobResources

--- a/helm/crds/sagemaker.services.k8s.aws_modelpackagegroups.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_modelpackagegroups.yaml
@@ -1,0 +1,142 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: modelpackagegroups.sagemaker.services.k8s.aws
+spec:
+  group: sagemaker.services.k8s.aws
+  names:
+    kind: ModelPackageGroup
+    listKind: ModelPackageGroupList
+    plural: modelpackagegroups
+    singular: modelpackagegroup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.modelPackageGroupStatus
+      name: STATUS
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ModelPackageGroup is the Schema for the ModelPackageGroups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: "ModelPackageGroupSpec defines the desired state of ModelPackageGroup.
+              \n A group of versioned models in the model registry."
+            properties:
+              modelPackageGroupDescription:
+                description: A description for the model group.
+                type: string
+              modelPackageGroupName:
+                description: The name of the model group.
+                type: string
+              tags:
+                description: A list of key value pairs associated with the model group.
+                  For more information, see Tagging AWS resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
+                  in the AWS General Reference Guide.
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+            required:
+            - modelPackageGroupName
+            type: object
+          status:
+            description: ModelPackageGroupStatus defines the observed state of ModelPackageGroup
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelPackageGroupStatus:
+                description: The status of the model group.
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/helm/crds/sagemaker.services.k8s.aws_modelpackages.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_modelpackages.yaml
@@ -1,0 +1,437 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.6.1
+  creationTimestamp: null
+  name: modelpackages.sagemaker.services.k8s.aws
+spec:
+  group: sagemaker.services.k8s.aws
+  names:
+    kind: ModelPackage
+    listKind: ModelPackageList
+    plural: modelpackages
+    singular: modelpackage
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.modelPackageStatus
+      name: STATUS
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ModelPackage is the Schema for the ModelPackages API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: "ModelPackageSpec defines the desired state of ModelPackage.
+              \n A versioned model that can be deployed for SageMaker inference."
+            properties:
+              approvalDescription:
+                description: A description for the approval status of the model.
+                type: string
+              certifyForMarketplace:
+                description: "Whether to certify the model package for listing on
+                  AWS Marketplace. \n This parameter is optional for unversioned models,
+                  and does not apply to versioned models."
+                type: boolean
+              clientToken:
+                description: A unique token that guarantees that the call to this
+                  API is idempotent.
+                type: string
+              inferenceSpecification:
+                description: "Specifies details about inference jobs that can be run
+                  with models based on this model package, including the following:
+                  \n    * The Amazon ECR paths of containers that contain the inference
+                  code and    model artifacts. \n    * The instance types that the
+                  model package supports for transform jobs    and real-time endpoints
+                  used for inference. \n    * The input and output content formats
+                  that the model package supports    for inference."
+                properties:
+                  containers:
+                    items:
+                      description: Describes the Docker container for the model package.
+                      properties:
+                        containerHostname:
+                          type: string
+                        image:
+                          type: string
+                        imageDigest:
+                          type: string
+                        modelDataURL:
+                          type: string
+                        productID:
+                          type: string
+                      type: object
+                    type: array
+                  supportedContentTypes:
+                    items:
+                      type: string
+                    type: array
+                  supportedRealtimeInferenceInstanceTypes:
+                    items:
+                      type: string
+                    type: array
+                  supportedResponseMIMETypes:
+                    items:
+                      type: string
+                    type: array
+                  supportedTransformInstanceTypes:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              metadataProperties:
+                description: Metadata properties of the tracking entity, trial, or
+                  trial component.
+                properties:
+                  commitID:
+                    type: string
+                  generatedBy:
+                    type: string
+                  projectID:
+                    type: string
+                  repository:
+                    type: string
+                type: object
+              modelApprovalStatus:
+                description: "Whether the model is approved for deployment. \n This
+                  parameter is optional for versioned models, and does not apply to
+                  unversioned models. \n For versioned models, the value of this parameter
+                  must be set to Approved to deploy the model."
+                type: string
+              modelMetrics:
+                description: A structure that contains model metrics reports.
+                properties:
+                  bias:
+                    description: Contains bias metrics for a model.
+                    properties:
+                      report:
+                        properties:
+                          contentDigest:
+                            type: string
+                          contentType:
+                            type: string
+                          s3URI:
+                            type: string
+                        type: object
+                    type: object
+                  explainability:
+                    description: Contains explainability metrics for a model.
+                    properties:
+                      report:
+                        properties:
+                          contentDigest:
+                            type: string
+                          contentType:
+                            type: string
+                          s3URI:
+                            type: string
+                        type: object
+                    type: object
+                  modelDataQuality:
+                    description: Data quality constraints and statistics for a model.
+                    properties:
+                      constraints:
+                        properties:
+                          contentDigest:
+                            type: string
+                          contentType:
+                            type: string
+                          s3URI:
+                            type: string
+                        type: object
+                      statistics:
+                        properties:
+                          contentDigest:
+                            type: string
+                          contentType:
+                            type: string
+                          s3URI:
+                            type: string
+                        type: object
+                    type: object
+                  modelQuality:
+                    description: Model quality statistics and constraints.
+                    properties:
+                      constraints:
+                        properties:
+                          contentDigest:
+                            type: string
+                          contentType:
+                            type: string
+                          s3URI:
+                            type: string
+                        type: object
+                      statistics:
+                        properties:
+                          contentDigest:
+                            type: string
+                          contentType:
+                            type: string
+                          s3URI:
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              modelPackageDescription:
+                description: A description of the model package.
+                type: string
+              modelPackageGroupName:
+                description: "The name of the model group that this model version
+                  belongs to. \n This parameter is required for versioned models,
+                  and does not apply to unversioned models."
+                type: string
+              modelPackageName:
+                description: "The name of the model package. The name must have 1
+                  to 63 characters. Valid characters are a-z, A-Z, 0-9, and - (hyphen).
+                  \n This parameter is required for unversioned models. It is not
+                  applicable to versioned models."
+                type: string
+              sourceAlgorithmSpecification:
+                description: Details about the algorithm that was used to create the
+                  model package.
+                properties:
+                  sourceAlgorithms:
+                    items:
+                      description: Specifies an algorithm that was used to create
+                        the model package. The algorithm must be either an algorithm
+                        resource in your Amazon SageMaker account or an algorithm
+                        in AWS Marketplace that you are subscribed to.
+                      properties:
+                        algorithmName:
+                          type: string
+                        modelDataURL:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              tags:
+                description: A list of key value pairs associated with the model.
+                  For more information, see Tagging AWS resources (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html)
+                  in the AWS General Reference Guide.
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              validationSpecification:
+                description: Specifies configurations for one or more transform jobs
+                  that Amazon SageMaker runs to test the model package.
+                properties:
+                  validationProfiles:
+                    items:
+                      description: "Contains data, such as the inputs and targeted
+                        instance types that are used in the process of validating
+                        the model package. \n The data provided in the validation
+                        profile is made available to your buyers on AWS Marketplace."
+                      properties:
+                        profileName:
+                          type: string
+                        transformJobDefinition:
+                          description: Defines the input needed to run a transform
+                            job using the inference specification specified in the
+                            algorithm.
+                          properties:
+                            batchStrategy:
+                              type: string
+                            environment:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            maxConcurrentTransforms:
+                              format: int64
+                              type: integer
+                            maxPayloadInMB:
+                              format: int64
+                              type: integer
+                            transformInput:
+                              description: Describes the input source of a transform
+                                job and the way the transform job consumes it.
+                              properties:
+                                compressionType:
+                                  type: string
+                                contentType:
+                                  type: string
+                                dataSource:
+                                  description: Describes the location of the channel
+                                    data.
+                                  properties:
+                                    s3DataSource:
+                                      description: Describes the S3 data source.
+                                      properties:
+                                        s3DataType:
+                                          type: string
+                                        s3URI:
+                                          type: string
+                                      type: object
+                                  type: object
+                                splitType:
+                                  type: string
+                              type: object
+                            transformOutput:
+                              description: Describes the results of a transform job.
+                              properties:
+                                accept:
+                                  type: string
+                                assembleWith:
+                                  type: string
+                                kmsKeyID:
+                                  type: string
+                                s3OutputPath:
+                                  type: string
+                              type: object
+                            transformResources:
+                              description: Describes the resources, including ML instance
+                                types and ML instance count, to use for transform
+                                job.
+                              properties:
+                                instanceCount:
+                                  format: int64
+                                  type: integer
+                                instanceType:
+                                  type: string
+                                volumeKMSKeyID:
+                                  type: string
+                              type: object
+                          type: object
+                      type: object
+                    type: array
+                  validationRole:
+                    type: string
+                type: object
+            type: object
+          status:
+            description: ModelPackageStatus defines the observed state of ModelPackage
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              creationTime:
+                description: A timestamp specifying when the model package was created.
+                format: date-time
+                type: string
+              lastModifiedTime:
+                description: The last time the model package was modified.
+                format: date-time
+                type: string
+              modelApprovalStatus:
+                description: The approval status of the model package.
+                type: string
+              modelPackageStatus:
+                description: The current status of the model package.
+                type: string
+              modelPackageStatusDetails:
+                description: Details about the current status of the model package.
+                properties:
+                  imageScanStatuses:
+                    items:
+                      description: Represents the overall status of a model package.
+                      properties:
+                        failureReason:
+                          type: string
+                        name:
+                          type: string
+                        status:
+                          type: string
+                      type: object
+                    type: array
+                  validationStatuses:
+                    items:
+                      description: Represents the overall status of a model package.
+                      properties:
+                        failureReason:
+                          type: string
+                        name:
+                          type: string
+                        status:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/helm/crds/sagemaker.services.k8s.aws_modelqualityjobdefinitions.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_modelqualityjobdefinitions.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: modelqualityjobdefinitions.sagemaker.services.k8s.aws
 spec:
@@ -36,7 +36,7 @@ spec:
             type: object
           spec:
             description: ModelQualityJobDefinitionSpec defines the desired state of
-              ModelQualityJobDefinition
+              ModelQualityJobDefinition.
             properties:
               jobDefinitionName:
                 description: The name of the monitoring job definition.
@@ -195,6 +195,19 @@ spec:
                     format: int64
                     type: integer
                 type: object
+              tags:
+                description: (Optional) An array of key-value pairs. For more information,
+                  see Using Cost Allocation Tags (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html#allocation-whatURL)
+                  in the AWS Billing and Cost Management User Guide.
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
             required:
             - jobDefinitionName
             - jobResources

--- a/helm/crds/sagemaker.services.k8s.aws_models.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_models.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: models.sagemaker.services.k8s.aws
 spec:
@@ -34,7 +34,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: ModelSpec defines the desired state of Model
+            description: ModelSpec defines the desired state of Model.
             properties:
               containers:
                 description: Specifies the containers in the inference pipeline.
@@ -154,6 +154,20 @@ spec:
                         type: string
                     type: object
                 type: object
+              tags:
+                description: An array of key-value pairs. You can use tags to categorize
+                  your AWS resources in different ways, for example, by purpose, owner,
+                  or environment. For more information, see Tagging AWS Resources
+                  (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html).
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
               vpcConfig:
                 description: A VpcConfig object that specifies the VPC that you want
                   your model to connect to. Control access to and from your model

--- a/helm/crds/sagemaker.services.k8s.aws_monitoringschedules.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_monitoringschedules.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: monitoringschedules.sagemaker.services.k8s.aws
 spec:
@@ -18,10 +18,11 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.failureReason
-      name: FailureReason
+      name: FAILURE-REASON
+      priority: 1
       type: string
     - jsonPath: .status.monitoringScheduleStatus
-      name: MonitoringScheduleStatus
+      name: STATUS
       type: string
     name: v1alpha1
     schema:
@@ -42,7 +43,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: MonitoringScheduleSpec defines the desired state of MonitoringSchedule
+            description: "MonitoringScheduleSpec defines the desired state of MonitoringSchedule.
+              \n A schedule for a model monitoring job. For information about model
+              monitor, see Amazon SageMaker Model Monitor (https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor.html)."
             properties:
               monitoringScheduleConfig:
                 description: The configuration object that specifies the monitoring
@@ -226,6 +229,19 @@ spec:
                 description: The name of the monitoring schedule. The name must be
                   unique within an AWS Region within an AWS account.
                 type: string
+              tags:
+                description: (Optional) An array of key-value pairs. For more information,
+                  see Using Cost Allocation Tags (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html#allocation-whatURL)
+                  in the AWS Billing and Cost Management User Guide.
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
             required:
             - monitoringScheduleConfig
             - monitoringScheduleName

--- a/helm/crds/sagemaker.services.k8s.aws_processingjobs.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_processingjobs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: processingjobs.sagemaker.services.k8s.aws
 spec:
@@ -18,10 +18,11 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.failureReason
-      name: FailureReason
+      name: FAILURE-REASON
+      priority: 1
       type: string
     - jsonPath: .status.processingJobStatus
-      name: ProcessingJobStatus
+      name: STATUS
       type: string
     name: v1alpha1
     schema:
@@ -41,7 +42,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: ProcessingJobSpec defines the desired state of ProcessingJob
+            description: "ProcessingJobSpec defines the desired state of ProcessingJob.
+              \n An Amazon SageMaker processing job that is used to analyze data and
+              evaluate models. For more information, see Process Data and Evaluate
+              Models (https://docs.aws.amazon.com/sagemaker/latest/dg/processing-job.html)."
             properties:
               appSpecification:
                 description: Configures the processing job to run a specified Docker
@@ -285,6 +289,19 @@ spec:
                     format: int64
                     type: integer
                 type: object
+              tags:
+                description: (Optional) An array of key-value pairs. For more information,
+                  see Using Cost Allocation Tags (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html#allocation-whatURL)
+                  in the AWS Billing and Cost Management User Guide.
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
             required:
             - appSpecification
             - processingJobName

--- a/helm/crds/sagemaker.services.k8s.aws_trainingjobs.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_trainingjobs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: trainingjobs.sagemaker.services.k8s.aws
 spec:
@@ -18,13 +18,14 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.failureReason
-      name: FailureReason
+      name: FAILURE-REASON
+      priority: 1
       type: string
     - jsonPath: .status.secondaryStatus
-      name: SecondaryStatus
+      name: SECONDARY-STATUS
       type: string
     - jsonPath: .status.trainingJobStatus
-      name: TrainingJobStatus
+      name: STATUS
       type: string
     name: v1alpha1
     schema:
@@ -44,7 +45,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: TrainingJobSpec defines the desired state of TrainingJob
+            description: "TrainingJobSpec defines the desired state of TrainingJob.
+              \n Contains information about a training job."
             properties:
               algorithmSpecification:
                 description: The registry path of the Docker image that contains the
@@ -382,6 +384,20 @@ spec:
                     format: int64
                     type: integer
                 type: object
+              tags:
+                description: An array of key-value pairs. You can use tags to categorize
+                  your AWS resources in different ways, for example, by purpose, owner,
+                  or environment. For more information, see Tagging AWS Resources
+                  (https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html).
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
               tensorBoardOutputConfig:
                 description: Configuration of storage locations for the Debugger TensorBoard
                   output data.

--- a/helm/crds/sagemaker.services.k8s.aws_transformjobs.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_transformjobs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: transformjobs.sagemaker.services.k8s.aws
 spec:
@@ -18,10 +18,11 @@ spec:
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.failureReason
-      name: FailureReason
+      name: FAILURE-REASON
+      priority: 1
       type: string
     - jsonPath: .status.transformJobStatus
-      name: TransformJobStatus
+      name: STATUS
       type: string
     name: v1alpha1
     schema:
@@ -41,7 +42,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: TransformJobSpec defines the desired state of TransformJob
+            description: "TransformJobSpec defines the desired state of TransformJob.
+              \n A batch transform job. For information about SageMaker batch transform,
+              see Use Batch Transform (https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html)."
             properties:
               batchStrategy:
                 description: "Specifies the number of records to include in a mini-batch
@@ -131,6 +134,19 @@ spec:
                   job. ModelName must be the name of an existing Amazon SageMaker
                   model within an AWS Region in an AWS account.
                 type: string
+              tags:
+                description: (Optional) An array of key-value pairs. For more information,
+                  see Using Cost Allocation Tags (https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html#allocation-what)
+                  in the AWS Billing and Cost Management User Guide.
+                items:
+                  description: Describes a tag.
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
               transformInput:
                 description: Describes the input source and the way the transform
                   job consumes it.

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: adoptedresources.services.k8s.aws
 spec:
@@ -40,6 +40,12 @@ spec:
                 description: AWSIdentifiers provide all unique ways to reference an
                   AWS resource.
                 properties:
+                  additionalKeys:
+                    additionalProperties:
+                      type: string
+                    description: AdditionalKeys represents any additional arbitrary
+                      identifiers used when describing the target resource.
+                    type: object
                   arn:
                     description: ARN is the AWS Resource Name for the resource. It
                       is a globally unique identifier.

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -85,6 +85,26 @@ rules:
 - apiGroups:
   - sagemaker.services.k8s.aws
   resources:
+  - featuregroups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - sagemaker.services.k8s.aws
+  resources:
+  - featuregroups/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - sagemaker.services.k8s.aws
+  resources:
   - hyperparametertuningjobs
   verbs:
   - create
@@ -138,6 +158,46 @@ rules:
   - sagemaker.services.k8s.aws
   resources:
   - modelexplainabilityjobdefinitions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - sagemaker.services.k8s.aws
+  resources:
+  - modelpackagegroups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - sagemaker.services.k8s.aws
+  resources:
+  - modelpackagegroups/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - sagemaker.services.k8s.aws
+  resources:
+  - modelpackages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - sagemaker.services.k8s.aws
+  resources:
+  - modelpackages/status
   verbs:
   - get
   - patch

--- a/helm/templates/metrics-service.yaml
+++ b/helm/templates/metrics-service.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.metrics.service.create }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "app.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    k8s-app: {{ include "app.name" . }}
+    helm.sh/chart: {{ include "chart.name-version" . }}
+    control-plane: controller
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "app.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: Helm
+    k8s-app: {{ include "app.name" . }}
+{{- range $key, $value := .Values.deployment.labels }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
+  type: {{ .Values.metrics.service.type }}
+  ports:
+  - name: metricsport
+    port: 8080
+    targetPort: 8080
+    protocol: TCP
+{{- end }}

--- a/helm/templates/role-reader.yaml
+++ b/helm/templates/role-reader.yaml
@@ -12,10 +12,13 @@ rules:
   - dataqualityjobdefinitions
   - endpoints
   - endpointconfigs
+  - featuregroups
   - hyperparametertuningjobs
   - models
   - modelbiasjobdefinitions
   - modelexplainabilityjobdefinitions
+  - modelpackages
+  - modelpackagegroups
   - modelqualityjobdefinitions
   - monitoringschedules
   - processingjobs

--- a/helm/templates/role-writer.yaml
+++ b/helm/templates/role-writer.yaml
@@ -15,6 +15,8 @@ rules:
 
   - endpointconfigs
 
+  - featuregroups
+
   - hyperparametertuningjobs
 
   - models
@@ -22,6 +24,10 @@ rules:
   - modelbiasjobdefinitions
 
   - modelexplainabilityjobdefinitions
+
+  - modelpackages
+
+  - modelpackagegroups
 
   - modelqualityjobdefinitions
 
@@ -47,10 +53,13 @@ rules:
   - dataqualityjobdefinitions
   - endpoints
   - endpointconfigs
+  - featuregroups
   - hyperparametertuningjobs
   - models
   - modelbiasjobdefinitions
   - modelexplainabilityjobdefinitions
+  - modelpackages
+  - modelpackagegroups
   - modelqualityjobdefinitions
   - monitoringschedules
   - processingjobs

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -3,8 +3,8 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: public.ecr.aws/aws-controllers-k8s/controller
-  tag: sagemaker-v0.0.1
+  repository: public.ecr.aws/aws-controller-k8s/sagemaker-controller
+  tag: v0.0.2
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -15,6 +15,15 @@ deployment:
   annotations: {}
   labels: {}
   containerPort: 8080
+
+metrics:
+  service:
+    # Set to true to automatically create a Kubernetes Service resource for the
+    # Prometheus metrics server endpoint in controller
+    create: false
+    # Which Type to use for the Kubernetes Service?
+    # See: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+    type: "ClusterIP"
 
 resources:
   requests:
@@ -31,7 +40,7 @@ aws:
 
 # log level for the controller
 log:
-  enable_development_logging: false
+  enable_development_logging: true
   level: debug
 
 # If specified, the service controller will watch for object creation only in the provided namespace


### PR DESCRIPTION
Release artifacts for v0.0.2

Manual changes to helm charts:
- Enabled debug logging since its a pre-release
  ```
  log:
    enable_development_logging: false
    enable_development_logging: true
  ```
- removed `--endpoint-url` from deployment and values.yaml
- Default image repo was set to `u2r4f3v7`. changed to `aws-controller-k8s`
  ```
  image:
    repository: public.ecr.aws/aws-controller-k8s/sagemaker-controller
  ```
  
### Testing
PR build


### Release notes draft

This release includes the following resources and updates:
- Feature Group
- ModelPackageGroup
- ModelPackage
  - Adopting resource not supported
- Periodic infinite requeue for endpoint and monitoring schedule
  - Requeues periodically even after the resource is in sync to check the latest status from the service. E.g. scaling activity updates the instanceCount for a variant in endpoint
- Tag support
  - Supported during resource creation
  - Updates not supported for tags
- Changes to printer columns
- Runtime update to 0.6.0
  - Please refer to https://github.com/aws-controllers-k8s/runtime/releases for a detailed list of changes
  - Some important changes,  
    - Introduces additional debug level logs
    - Ability to patch a resource post delete
    - Support additional keys for adopted resource
   