### PR TITLE
[Feature Group] Unit Testing

### DIFF
--- a/pkg/resource/feature_group/manager_test_suite_test.go
+++ b/pkg/resource/feature_group/manager_test_suite_test.go
@@ -16,6 +16,12 @@ package feature_group
 import (
 	"errors"
 	"fmt"
+	"os"
+	"io/ioutil"
+	"os/exec"
+
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	"github.com/ghodss/yaml"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
@@ -27,6 +33,12 @@ import (
 	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	"go.uber.org/zap/zapcore"
+)
+
+var (
+	DefaultTimestamp = "0001-01-01T00:00:00Z"
+	ReplaceTimestampRegExp = "s/\"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\"/\"" + DefaultTimestamp + "\"/"
+	TestDataDirectory = "testdata"
 )
 
 // provideResourceManagerWithMockSDKAPI accepts MockSageMakerAPI and returns pointer to resourceManager
@@ -48,8 +60,8 @@ func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMa
 	}
 }
 
-// TestDeclarativeTestSuite runs the test suite for feature group
-func TestDeclarativeTestSuite(t *testing.T) {
+// TestFeatureGroupTestSuite runs the test suite for feature group
+func TestFeatureGroupTestSuite(t *testing.T) {
      	defer func() {
      	   if r := recover(); r != nil {
      	      fmt.Println(testutil.RecoverPanicString, r)
@@ -88,7 +100,7 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	switch apiName {
 	case "CreateFeatureGroupWithContext":
 		var output svcsdk.CreateFeatureGroupOutput
-	    	return &output, nil
+		return &output, nil
 	case "DeleteFeatureGroupWithContext":
 		var output svcsdk.DeleteFeatureGroupOutput
 		return &output, nil
@@ -102,7 +114,8 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResource) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	// Ignore LastTransitionTime since it gets updated each run.
+	opts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.IgnoreFields(ackv1alpha1.Condition{}, "LastTransitionTime")}
 
 	if cmp.Equal(ac.ko.Status, bc.ko.Status, opts...) {
 		return true
@@ -111,4 +124,79 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 		fmt.Println(cmp.Diff(ac.ko.Status, bc.ko.Status, opts...))
 		return false
 	}
+}
+
+// Checks to see if the given yaml file, with name stored as expectation,
+// matches the yaml marshal of the AWSResource stored as actual.
+func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
+     	// Get the file name of the expected yaml.
+	expectedYamlFileName := TestDataDirectory + "/" + expectation
+
+	// Build a tmp file for the actual yaml.
+	actualResource := actual.(*resource)
+	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
+	actualYamlFileName := buildTmpFile("actualYaml", actualYamlByteArray)
+	defer os.Remove(actualYamlFileName)
+	if "" == actualYamlFileName {
+	  fmt.Printf("Could not create temporary actual file.\n")
+	  return false
+	}
+
+	// Replace Timestamps that would show up as different.
+	_, err := exec.Command("sed", "-r", "-i", ReplaceTimestampRegExp, actualYamlFileName).Output()
+	if isExecCommandError(err) {
+	    return false
+	}
+	
+	output,err := exec.Command("diff", "-c", expectedYamlFileName, actualYamlFileName).Output()
+	if isExecCommandError(err) {
+	   return false
+	}
+
+	if len(output) > 0 {
+	   actualOutput,err := exec.Command("cat", actualYamlFileName).Output()
+	   if isExecCommandError(err) {
+	      return false
+	   }
+	   fmt.Printf("\nExpected Yaml File Name: " + expectedYamlFileName + "\n")
+	   fmt.Printf("\nActual Output Yaml:\n" + string(actualOutput) + "\n")
+	   fmt.Printf("Diff From Expected:\n" + string(output) + "\n")
+	   return false
+	}
+	return true
+}
+
+func buildTmpFile(fileNameBase string, contents []byte) string {
+     newTmpFile, err := ioutil.TempFile(TestDataDirectory, fileNameBase)
+     if err != nil {
+        fmt.Println(err)
+	return ""
+     }
+     if _, err := newTmpFile.Write(contents); err != nil {
+        fmt.Println(err)
+	return ""
+     }
+     if err := newTmpFile.Close(); err != nil {
+        fmt.Println(err)
+	return ""
+     }		
+     return newTmpFile.Name()
+}
+
+// isExecCommandError returns true if an error
+// that is not an ExitError is found.
+func isExecCommandError(err error) bool {
+     if err == nil {
+     	return false
+     }
+     switch err.(type) {
+	case *exec.ExitError:
+	       // ExitError is expected.
+	       return false
+	default:
+	       // Couldn't run diff.
+	       fmt.Printf("Exec Command Error: ")
+	       fmt.Println(err)
+	       return true
+     }
 }

--- a/pkg/resource/feature_group/testdata/feature_group/create/fg_before_create.json
+++ b/pkg/resource/feature_group/testdata/feature_group/create/fg_before_create.json
@@ -1,0 +1,3 @@
+{
+    "FeatureGroupArn": "arn:aws:sagemaker:us-west-2:123456789012:feature-group/unit-testing-feature-group"
+}

--- a/pkg/resource/feature_group/testdata/feature_group/read_one/fg_create_failed.json
+++ b/pkg/resource/feature_group/testdata/feature_group/read_one/fg_create_failed.json
@@ -1,0 +1,33 @@
+{
+  "CreationTime": "2021-07-28T00:32:45.698Z",
+  "Description": null,
+  "EventTimeFeatureName": "EventTime",
+  "FailureReason": null,
+  "FeatureDefinitions": [
+    {
+      "FeatureName": "TransactionID",
+      "FeatureType": "Integral"
+    },
+    {
+      "FeatureName": "EventTime",
+      "FeatureType": "Fractional"
+    }
+  ],
+    "FeatureGroupArn": "arn:aws:sagemaker:us-west-2:123456789012:feature-group/unit-testing-feature-group",
+  "FeatureGroupName": "unit-testing-feature-group",
+  "FeatureGroupStatus": "CreateFailed",
+  "NextToken": null,
+  "OfflineStoreConfig": {
+    "DataCatalogConfig": null,
+    "DisableGlueTableCreation": false,
+    "S3StorageConfig": {
+      "KmsKeyId": null,
+      "ResolvedOutputS3Uri": "s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data/123456789012/sagemaker/us-west-2/offline-store/unit-testing-feature-group-1627432365/data",
+      "S3Uri": "s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data"
+    }
+  },
+  "OfflineStoreStatus": null,
+  "OnlineStoreConfig": null,
+  "RecordIdentifierFeatureName": "TransactionID",
+  "RoleArn": "arn:aws:iam::123456789012:role/ack-sagemaker-execution-role"
+}

--- a/pkg/resource/feature_group/testdata/feature_group/read_one/fg_created.json
+++ b/pkg/resource/feature_group/testdata/feature_group/read_one/fg_created.json
@@ -1,0 +1,37 @@
+{
+  "CreationTime": "2021-07-28T00:45:46.813Z",
+  "Description": null,
+  "EventTimeFeatureName": "EventTime",
+  "FailureReason": null,
+  "FeatureDefinitions": [
+    {
+      "FeatureName": "TransactionID",
+      "FeatureType": "Integral"
+    },
+    {
+      "FeatureName": "EventTime",
+      "FeatureType": "Fractional"
+    }
+  ],
+  "FeatureGroupArn": "arn:aws:sagemaker:us-west-2:123456789012:feature-group/unit-testing-feature-group",
+  "FeatureGroupName": "unit-testing-feature-group",
+  "FeatureGroupStatus": "Created",
+  "NextToken": null,
+  "OfflineStoreConfig": {
+    "DataCatalogConfig": {
+      "Catalog": "AwsDataCatalog",
+      "Database": "sagemaker_featurestore",
+      "TableName": "unit-testing-feature-group-1627433146"
+    },
+    "DisableGlueTableCreation": false,
+    "S3StorageConfig": {
+      "KmsKeyId": null,
+      "ResolvedOutputS3Uri": "s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data/123456789012/sagemaker/us-west-2/offline-store/unit-testing-feature-group-1627433146/data",
+      "S3Uri": "s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data"
+    }
+  },
+  "OfflineStoreStatus": null,
+  "OnlineStoreConfig": null,
+  "RecordIdentifierFeatureName": "TransactionID",
+  "RoleArn": "arn:aws:iam::123456789012:role/ack-sagemaker-execution-role"
+}

--- a/pkg/resource/feature_group/testdata/feature_group/read_one/fg_creating.json
+++ b/pkg/resource/feature_group/testdata/feature_group/read_one/fg_creating.json
@@ -1,0 +1,33 @@
+{
+  "CreationTime": "2021-07-28T00:32:45.698Z",
+  "Description": null,
+  "EventTimeFeatureName": "EventTime",
+  "FailureReason": null,
+  "FeatureDefinitions": [
+    {
+      "FeatureName": "TransactionID",
+      "FeatureType": "Integral"
+    },
+    {
+      "FeatureName": "EventTime",
+      "FeatureType": "Fractional"
+    }
+  ],
+  "FeatureGroupArn": "arn:aws:sagemaker:us-west-2:123456789012:feature-group/unit-testing-feature-group",
+  "FeatureGroupName": "unit-testing-feature-group",
+  "FeatureGroupStatus": "Creating",
+  "NextToken": null,
+  "OfflineStoreConfig": {
+    "DataCatalogConfig": null,
+    "DisableGlueTableCreation": false,
+    "S3StorageConfig": {
+      "KmsKeyId": null,
+      "ResolvedOutputS3Uri": "s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data/123456789012/sagemaker/us-west-2/offline-store/unit-testing-feature-group-1627432365/data",
+      "S3Uri": "s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data"
+    }
+  },
+  "OfflineStoreStatus": null,
+  "OnlineStoreConfig": null,
+  "RecordIdentifierFeatureName": "TransactionID",
+  "RoleArn": "arn:aws:iam::123456789012:role/ack-sagemaker-execution-role"
+}

--- a/pkg/resource/feature_group/testdata/feature_group/read_one/fg_deleting.json
+++ b/pkg/resource/feature_group/testdata/feature_group/read_one/fg_deleting.json
@@ -1,0 +1,37 @@
+{
+  "CreationTime": "2021-07-28T00:45:46.813Z",
+  "Description": null,
+  "EventTimeFeatureName": "EventTime",
+  "FailureReason": null,
+  "FeatureDefinitions": [
+    {
+      "FeatureName": "TransactionID",
+      "FeatureType": "Integral"
+    },
+    {
+      "FeatureName": "EventTime",
+      "FeatureType": "Fractional"
+    }
+  ],
+  "FeatureGroupArn": "arn:aws:sagemaker:us-west-2:123456789012:feature-group/unit-testing-feature-group",
+  "FeatureGroupName": "unit-testing-feature-group",
+  "FeatureGroupStatus": "Deleting",
+  "NextToken": null,
+  "OfflineStoreConfig": {
+    "DataCatalogConfig": {
+      "Catalog": "AwsDataCatalog",
+      "Database": "sagemaker_featurestore",
+      "TableName": "unit-testing-feature-group-1627433146"
+    },
+    "DisableGlueTableCreation": false,
+    "S3StorageConfig": {
+      "KmsKeyId": null,
+      "ResolvedOutputS3Uri": "s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data/123456789012/sagemaker/us-west-2/offline-store/unit-testing-feature-group-1627433146/data",
+      "S3Uri": "s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data"
+    }
+  },
+  "OfflineStoreStatus": null,
+  "OnlineStoreConfig": null,
+  "RecordIdentifierFeatureName": "TransactionID",
+  "RoleArn": "arn:aws:iam::123456789012:role/ack-sagemaker-execution-role"
+}

--- a/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_before_create.yaml
+++ b/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_before_create.yaml
@@ -1,0 +1,17 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: FeatureGroup
+metadata:
+  name: unit-testing-feature-group
+spec:
+  eventTimeFeatureName: EventTime
+  featureDefinitions:
+  - featureName: TransactionID
+    featureType: Integral
+  - featureName: EventTime
+    featureType: Fractional
+  featureGroupName: unit-testing-feature-group
+  offlineStoreConfig:
+    s3StorageConfig:
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data
+  recordIdentifierFeatureName: TransactionID
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role

--- a/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_create_failed_state.yaml
+++ b/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_create_failed_state.yaml
@@ -1,0 +1,35 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: FeatureGroup
+metadata:
+  creationTimestamp: null
+  name: unit-testing-feature-group
+spec:
+  eventTimeFeatureName: EventTime
+  featureDefinitions:
+  - featureName: TransactionID
+    featureType: Integral
+  - featureName: EventTime
+    featureType: Fractional
+  featureGroupName: unit-testing-feature-group
+  offlineStoreConfig:
+    disableGlueTableCreation: false
+    s3StorageConfig:
+      resolvedOutputS3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data/123456789012/sagemaker/us-west-2/offline-store/unit-testing-feature-group-1627432365/data
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data
+  recordIdentifierFeatureName: TransactionID
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:feature-group/unit-testing-feature-group
+    ownerAccountID: ""
+  conditions:
+  - lastTransitionTime: "0001-01-01T00:00:00Z"
+    message: FeatureGroup is in CreateFailed status.
+    status: "True"
+    type: ACK.ResourceSynced
+  - lastTransitionTime: "0001-01-01T00:00:00Z"
+    message: 'FeatureGroup status reached terminal state: CreateFailed. Check the
+      FailureReason.'
+    status: "True"
+    type: ACK.Terminal
+  featureGroupStatus: CreateFailed

--- a/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_create_initiated.yaml
+++ b/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_create_initiated.yaml
@@ -1,0 +1,23 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: FeatureGroup
+metadata:
+  creationTimestamp: null
+  name: unit-testing-feature-group
+spec:
+  eventTimeFeatureName: EventTime
+  featureDefinitions:
+  - featureName: TransactionID
+    featureType: Integral
+  - featureName: EventTime
+    featureType: Fractional
+  featureGroupName: unit-testing-feature-group
+  offlineStoreConfig:
+    s3StorageConfig:
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data
+  recordIdentifierFeatureName: TransactionID
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:feature-group/unit-testing-feature-group
+    ownerAccountID: ""
+  conditions: []

--- a/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_created_state.yaml
+++ b/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_created_state.yaml
@@ -1,0 +1,34 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: FeatureGroup
+metadata:
+  creationTimestamp: null
+  name: unit-testing-feature-group
+spec:
+  eventTimeFeatureName: EventTime
+  featureDefinitions:
+  - featureName: TransactionID
+    featureType: Integral
+  - featureName: EventTime
+    featureType: Fractional
+  featureGroupName: unit-testing-feature-group
+  offlineStoreConfig:
+    dataCatalogConfig:
+      catalog: AwsDataCatalog
+      database: sagemaker_featurestore
+      tableName: unit-testing-feature-group-1627433146
+    disableGlueTableCreation: false
+    s3StorageConfig:
+      resolvedOutputS3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data/123456789012/sagemaker/us-west-2/offline-store/unit-testing-feature-group-1627433146/data
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data
+  recordIdentifierFeatureName: TransactionID
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:feature-group/unit-testing-feature-group
+    ownerAccountID: ""
+  conditions:
+  - lastTransitionTime: "0001-01-01T00:00:00Z"
+    message: FeatureGroup is in Created status.
+    status: "True"
+    type: ACK.ResourceSynced
+  featureGroupStatus: Created

--- a/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_creating_state.yaml
+++ b/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_creating_state.yaml
@@ -1,0 +1,30 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: FeatureGroup
+metadata:
+  creationTimestamp: null
+  name: unit-testing-feature-group
+spec:
+  eventTimeFeatureName: EventTime
+  featureDefinitions:
+  - featureName: TransactionID
+    featureType: Integral
+  - featureName: EventTime
+    featureType: Fractional
+  featureGroupName: unit-testing-feature-group
+  offlineStoreConfig:
+    disableGlueTableCreation: false
+    s3StorageConfig:
+      resolvedOutputS3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data/123456789012/sagemaker/us-west-2/offline-store/unit-testing-feature-group-1627432365/data
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data
+  recordIdentifierFeatureName: TransactionID
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:feature-group/unit-testing-feature-group
+    ownerAccountID: ""
+  conditions:
+  - lastTransitionTime: "0001-01-01T00:00:00Z"
+    message: FeatureGroup is in Creating status.
+    status: "False"
+    type: ACK.ResourceSynced
+  featureGroupStatus: Creating

--- a/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_deleting_state.yaml
+++ b/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_deleting_state.yaml
@@ -1,0 +1,34 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: FeatureGroup
+metadata:
+  creationTimestamp: null
+  name: unit-testing-feature-group
+spec:
+  eventTimeFeatureName: EventTime
+  featureDefinitions:
+  - featureName: TransactionID
+    featureType: Integral
+  - featureName: EventTime
+    featureType: Fractional
+  featureGroupName: unit-testing-feature-group
+  offlineStoreConfig:
+    dataCatalogConfig:
+      catalog: AwsDataCatalog
+      database: sagemaker_featurestore
+      tableName: unit-testing-feature-group-1627433146
+    disableGlueTableCreation: false
+    s3StorageConfig:
+      resolvedOutputS3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data/123456789012/sagemaker/us-west-2/offline-store/unit-testing-feature-group-1627433146/data
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data
+  recordIdentifierFeatureName: TransactionID
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:feature-group/unit-testing-feature-group
+    ownerAccountID: ""
+  conditions:
+  - lastTransitionTime: "0001-01-01T00:00:00Z"
+    message: FeatureGroup is in Deleting status.
+    status: "False"
+    type: ACK.ResourceSynced
+  featureGroupStatus: Deleting

--- a/pkg/resource/feature_group/testdata/test_suite.yaml
+++ b/pkg/resource/feature_group/testdata/test_suite.yaml
@@ -2,16 +2,89 @@ tests:
   - name: "Feature group create test."
     description: "Feature group CRD tests"
     scenarios:
-     - name: "Create=InvalidInput"
-       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
-       given:
-         desired_state: "feature_group/v1alpha1/fg_invalid_before_create.yaml"
-         svc_api:
-           - operation: CreateFeatureGroupWithContext
-             error:
-               code: InvalidParameterValue
-               message: "The feature group name must start with an alphanumeric character."
-       invoke: Create
-       expect:
-         latest_state: "feature_group/v1alpha1/fg_invalid_create_attempted.yaml"
-         error: resource is in terminal condition
+      - name: "Create=InvalidInput"
+        description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+        given:
+          desired_state: "feature_group/v1alpha1/fg_invalid_before_create.yaml"
+          svc_api:
+            - operation: CreateFeatureGroupWithContext
+              error:
+                code: InvalidParameterValue
+                message: "The feature group name must start with an alphanumeric character."
+        invoke: Create
+        expect:
+          latest_state: "feature_group/v1alpha1/fg_invalid_create_attempted.yaml"
+          error: resource is in terminal condition
+      - name: "Create=Sucess"
+        description: "Create a new feature group successfully (feature group ARN in the status ackResourceMetadata)."
+        given:
+          desired_state: "feature_group/v1alpha1/fg_before_create.yaml"
+          svc_api:
+            - operation: CreateFeatureGroupWithContext
+              output_fixture: "feature_group/create/fg_before_create.json"
+        invoke: Create
+        expect:
+          latest_state: "feature_group/v1alpha1/fg_create_initiated.yaml"
+          error: nil
+      - name: "ReadOne=NewlyCreated"
+        description: "A create initialized feature group enters the creating state with the ACK.ResourceSynced set to false, and the offlineStorageConfig disableGlueTableCreation, s3StorageConfig.resolvedOutputS3URI should be updated."
+        given:
+          # Feature group is creating, but creating has not yet finished
+          desired_state: "feature_group/v1alpha1/fg_create_initiated.yaml" 
+          svc_api:
+            - operation: DescribeFeatureGroupWithContext
+              output_fixture: "feature_group/read_one/fg_creating.json"
+        invoke: ReadOne
+        expect:
+          latest_state: "feature_group/v1alpha1/fg_creating_state.yaml"
+          error: nil
+      - name: "ReadOne=CreateFailed"
+        description: "A feature group in the creating state which enters the create failed state will have the terminal condition set to True."
+        given:
+          # Feature group is creating, but creating has not yet finished
+          desired_state: "feature_group/v1alpha1/fg_creating_state.yaml" 
+          svc_api:
+            - operation: DescribeFeatureGroupWithContext
+              output_fixture: "feature_group/read_one/fg_create_failed.json"
+        invoke: ReadOne
+        expect:
+          latest_state: "feature_group/v1alpha1/fg_create_failed_state.yaml"
+          error: nil
+      - name: "ReadOne=Created"
+        description: "A feature group in the creating state which enters the created state will have the ACK.ResourceSynced condition set to true, and the offlineStoreConfig dataCatalogConfig should be updated in the spec."
+        given:
+          # Feature group is creating, but creating has not yet finished
+          desired_state: "feature_group/v1alpha1/fg_creating_state.yaml" 
+          svc_api:
+            - operation: DescribeFeatureGroupWithContext
+              output_fixture: "feature_group/read_one/fg_created.json"
+        invoke: ReadOne
+        expect:
+          latest_state: "feature_group/v1alpha1/fg_created_state.yaml"
+          error: nil
+      - name: "Delete=RequiresRequeueWhileCreating"
+        description: "Deleting a feature group in a modifying condition (creating) should result in a requeue on delete."
+        given:
+          desired_state: "feature_group/v1alpha1/fg_creating_state.yaml"
+        invoke: Delete
+        expect:
+          error: "FeatureGroup in Creating state cannot be modified or deleted."
+      - name: "Delete=RequiresRequeueWhileDeleting"
+        description: "Deleting a feature group in a modifying condition (deleting) should result in a requeue on delete."
+        given:
+          desired_state: "feature_group/v1alpha1/fg_deleting_state.yaml"
+        invoke: Delete
+        expect:
+          error: "FeatureGroup in Deleting state cannot be modified or deleted."
+      - name: "Delete=Immediate"
+        description: "Deleting a feature group in the created state should enter the deleting state."
+        given:
+          desired_state: "feature_group/v1alpha1/fg_created_state.yaml"
+          svc_api:
+          - operation: DeleteFeatureGroupWithContext
+          # If there is no output_fixture or error, the mock returns nil for the object and the error
+          - operation: DescribeFeatureGroupWithContext
+            output_fixture: "feature_group/read_one/fg_deleting.json"
+        invoke: Delete
+        expect:
+          error: "FeatureGroup is deleting."

--- a/pkg/resource/feature_group/testdata/test_suite.yaml
+++ b/pkg/resource/feature_group/testdata/test_suite.yaml
@@ -1,6 +1,6 @@
 tests:
-  - name: "Feature group create test."
-    description: "Feature group CRD tests"
+  - name: "Feature group create tests"
+    description: "Part of feature group CRD tests."
     scenarios:
       - name: "Create=InvalidInput"
         description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
@@ -26,6 +26,9 @@ tests:
         expect:
           latest_state: "feature_group/v1alpha1/fg_create_initiated.yaml"
           error: nil
+  - name: "Feature group read one tests"
+    description: "Part of feature group CRD tests."
+    scenarios:
       - name: "ReadOne=NewlyCreated"
         description: "A create initialized feature group enters the creating state with the ACK.ResourceSynced set to false, and the offlineStorageConfig disableGlueTableCreation, s3StorageConfig.resolvedOutputS3URI should be updated."
         given:
@@ -62,6 +65,9 @@ tests:
         expect:
           latest_state: "feature_group/v1alpha1/fg_created_state.yaml"
           error: nil
+  - name: "Feature group delete tests"
+    description: "Part of feature group CRD tests."
+    scenarios:
       - name: "Delete=RequiresRequeueWhileCreating"
         description: "Deleting a feature group in a modifying condition (creating) should result in a requeue on delete."
         given:

--- a/pkg/testutil/test_suite_config.go
+++ b/pkg/testutil/test_suite_config.go
@@ -51,7 +51,7 @@ type Fixture struct {
 // ServiceAPI represents details about the the service sdk api and fixture path to mock its response
 type ServiceAPI struct {
 	Operation       string           `json:"operation"`
-	Output          string           `json:"output_fixture"`
+	Output          string           `json:"output_fixture,omitempty"`
 	ServiceAPIError *ServiceAPIError `json:"error,omitempty"`
 }
 

--- a/pkg/testutil/test_suite_runner.go
+++ b/pkg/testutil/test_suite_runner.go
@@ -54,6 +54,7 @@ type expectContext struct {
 type TestRunnerDelegate interface {
 	ResourceDescriptor() acktypes.AWSResourceDescriptor
 	Equal(desired acktypes.AWSResource, latest acktypes.AWSResource) bool // remove it when ResourceDescriptor.Delta() is available
+	YamlEqual(expected string, actual acktypes.AWSResource) bool // new
 	ResourceManager(*mocksvcsdkapi.SageMakerAPI) acktypes.AWSResourceManager
 	EmptyServiceAPIOutput(apiName string) (interface{}, error)
 	GoTestRunner() *testing.T
@@ -92,26 +93,25 @@ func (runner *TestSuiteRunner) startScenario (scenario TestScenario) {
 
 // runTestScenario runs given test scenario which is expressed as: given fixture context, unit to test, expected fixture context.
 func (runner *TestSuiteRunner) runTestScenario(t *testing.T, scenarioName string, fixtureCxt *fixtureContext, unitUnderTest string, expectation *Expect) {
-	//t.Run(scenarioName, func(t *testing.T) {
-	rm := fixtureCxt.resourceManager
-	assert := assert.New(t)
+     rm := fixtureCxt.resourceManager
+     assert := assert.New(t)
 
-	var actual acktypes.AWSResource = nil
-	var err error = nil
-	switch unitUnderTest {
-	case "ReadOne":
-		actual, err = rm.ReadOne(context.Background(), fixtureCxt.desired)
-	case "Create":
-		actual, err = rm.Create(context.Background(), fixtureCxt.desired)
-	case "Update":
-		delta := runner.Delegate.ResourceDescriptor().Delta(fixtureCxt.desired, fixtureCxt.latest)
-		actual, err = rm.Update(context.Background(), fixtureCxt.desired, fixtureCxt.latest, delta)
-	case "Delete":
-		actual, err = rm.Delete(context.Background(), fixtureCxt.desired)
-	default:
-		panic(errors.New(fmt.Sprintf("unit under test: %s not supported", unitUnderTest)))
-	}
-	runner.assertExpectations(assert, expectation, actual, err)
+     var actual acktypes.AWSResource = nil
+     var err error = nil
+     switch unitUnderTest {
+     case "ReadOne":
+     	  actual, err = rm.ReadOne(context.Background(), fixtureCxt.desired)
+     case "Create":
+     	  actual, err = rm.Create(context.Background(), fixtureCxt.desired)
+     case "Update":
+     	  delta := runner.Delegate.ResourceDescriptor().Delta(fixtureCxt.desired, fixtureCxt.latest)
+     	  actual, err = rm.Update(context.Background(), fixtureCxt.desired, fixtureCxt.latest, delta)
+     case "Delete":
+     	  actual, err = rm.Delete(context.Background(), fixtureCxt.desired)
+     default:
+	panic(errors.New(fmt.Sprintf("unit under test: %s not supported", unitUnderTest)))
+     }
+     runner.assertExpectations(assert, expectation, actual, err)
 }
 
 /* assertExpectations validates the actual outcome against the expected outcome.
@@ -145,9 +145,13 @@ func (runner *TestSuiteRunner) assertExpectations(assert *assert.Assertions, exp
 			fmt.Println("Unexpected differences:")
 			for _, difference := range delta.Differences {
 				fmt.Printf("Path: %v, expected: %v, actual: %v\n", difference.Path, difference.A, difference.B)
+				fmt.Printf("See expected differences below:\n")
 			}
 		}
 
+		// Check that the yaml files are equivalent.
+		// This makes it easier to make changes to unit test cases.
+		assert.True(runner.Delegate.YamlEqual(expectation.LatestState, actual))
 		// Delta only contains `Spec` differences. Thus, we need Delegate.Equal to compare `Status`.
 		assert.True(runner.Delegate.Equal(expectedLatest, actual))
 	}
@@ -189,6 +193,9 @@ func (runner *TestSuiteRunner) setupFixtureContext(fixture *Fixture) *fixtureCon
 				if err != nil {
 					panic(err)
 				}
+			} else if serviceApi.ServiceAPIError == nil && serviceApi.Output == "" {
+			        // Default case for no defined output fixture or error.
+			        mocksdkapi.On(serviceApi.Operation, mock.Anything, mock.Anything).Return(nil, nil)
 			}
 		}
 	}


### PR DESCRIPTION
Note:
This PR is meant to be merged on top of [PR #66](https://github.com/aws-controllers-k8s/sagemaker-controller/pull/66).

Summary:
Added unit test to feature group for Create, ReadOne, and Delete (Feature Group does not support Update). Includes testing of state transitions. Code coverage for Feature Group = 53.9%.

Total Code Coverage: 3.1%

Files Added:

- pkg/resource/feature_group/testdata/feature_group/v1alpha1 - Contains yaml files to be used in the desired and expected fields for testing scenarios in test_suite.yaml. (8 files)
   - fg_before_create.yaml
   - fg_create_failed_state.yaml
   - fg_create_initiated.yaml
   - fg_created_state.yaml
   - fg_creating_state.yaml
   - fg_deleting_state.yaml
   - fg_invalid_before_create.yaml
   - fg_invalid_create_attempted.yaml
- pkg/resource/feature_group/testdata/feature_group/create - Contains json files to be used in the output_fixture fields for testing scenarios in test_suite.yaml which invoke the Create operation. (1 file)
   - fg_before_create.json
- pkg/resource/feature_group/testdata/feature_group/read_one- Contains json files to be used in the output_fixture fields for testing scenarios in test_suite.yaml which invoke the ReadOne operation. (4 files)
   - fg_create_failed.json
   - fg_created.json
   - fg_creating.json
   - fg_deleting.json

Files Edited:

- pkg/common/custom_conditions.go - fixed bug revealed by unit test (needed to remove the space in "Create Failed" to do a compare to the terminal state)
- pkg/resource/feature_group/manager_test_suite_test.go - Added YamlEqual that is used in test_suite_runner.go and compares the expected and actual resource as yaml files, presenting a diff output (and a copy of the actual output) which is easy to understand and use to modify the yaml files for testing. Also changed the Equal function to ignore the "LastTransitionTime" since as a timestamp it is updated while testing, and cannot be correctly preset in the expected output yaml file.
- pkg/resource/feature_group/testdata/test_suite.yaml - Added state transition testing.
- pkg/testutil/test_suite_runner.go - Added assert for the YamlEqual function to test the outputs of unit testing, and added YamlEqual to the TestRunnerDelegate interface. Also added option for unit testing scenario sdkapi mocking to have no provided output_fixture or error, and therefore mock both as being nil.