### PR TITLE
All Resources Unit Testing Set Up + Example

### DIFF
--- a/pkg/resource/data_quality_job_definition/manager_test_suite_test.go
+++ b/pkg/resource/data_quality_job_definition/manager_test_suite_test.go
@@ -11,15 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package feature_group
+package data_quality_job_definition
 
 import (
 	"errors"
 	"fmt"
-
+	
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/ghodss/yaml"
-	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
@@ -35,24 +35,24 @@ import (
 // provideResourceManagerWithMockSDKAPI accepts MockSageMakerAPI and returns pointer to resourceManager
 // the returned resourceManager is configured to use mockapi api.
 func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMakerAPI) *resourceManager {
-     zapOptions := ctrlrtzap.Options{
-     	    Development: true,
-	    Level:       zapcore.InfoLevel,
-     }
-     fakeLogger := ctrlrtzap.New(ctrlrtzap.UseFlagOptions(&zapOptions))
-     return &resourceManager{
-     	    rr:           nil,
-	    awsAccountID: "",
-	    awsRegion:    "",
-	    sess:         nil,
-	    sdkapi:       mockSageMakerAPI,
-	    log:          fakeLogger,
-	    metrics:      ackmetrics.NewMetrics("sagemaker"),
-     }
+	zapOptions := ctrlrtzap.Options{
+		Development: true,
+		Level:       zapcore.InfoLevel,
+	}
+	fakeLogger := ctrlrtzap.New(ctrlrtzap.UseFlagOptions(&zapOptions))
+	return &resourceManager{
+		rr:           nil,
+		awsAccountID: "",
+		awsRegion:    "",
+		sess:         nil,
+		sdkapi:       mockSageMakerAPI,
+		log:          fakeLogger,
+		metrics:      ackmetrics.NewMetrics("sagemaker"),
+	}
 }
 
-// TestFeatureGroupTestSuite runs the test suite for feature group
-func TestFeatureGroupTestSuite(t *testing.T) {
+// TestDataQualityJobDefinitionTestSuite runs the test suite for data quality job definition
+func TestDataQualityJobDefinitionTestSuite(t *testing.T) {
      	defer func() {
      	   if r := recover(); r != nil {
      	      fmt.Println(testutil.RecoverPanicString, r)
@@ -89,15 +89,15 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	}
 	//TODO: use reflection, template to auto generate this block/method.
 	switch apiName {
-	case "CreateFeatureGroupWithContext":
-		var output svcsdk.CreateFeatureGroupOutput
-		return &output, nil
-	case "DeleteFeatureGroupWithContext":
-		var output svcsdk.DeleteFeatureGroupOutput
-		return &output, nil
-	case "DescribeFeatureGroupWithContext":
-		var output svcsdk.DescribeFeatureGroupOutput
-		return &output, nil
+	case "CreateDataQualityJobDefinitionWithContext":
+		var output svcsdk.CreateDataQualityJobDefinitionOutput
+	    	return &output, nil
+	case "DescribeDataQualityJobDefinitionWithContext":
+		var output svcsdk.DescribeDataQualityJobDefinitionOutput
+	    	return &output, nil
+	case "DeleteDataQualityJobDefinitionWithContext":
+		var output svcsdk.DeleteDataQualityJobDefinitionOutput
+	    	return &output, nil
 	}
 	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))
 }

--- a/pkg/resource/data_quality_job_definition/testdata/data_quality_job_definition/v1alpha1/dqjd_invalid_before_create.yaml
+++ b/pkg/resource/data_quality_job_definition/testdata/data_quality_job_definition/v1alpha1/dqjd_invalid_before_create.yaml
@@ -1,0 +1,41 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: DataQualityJobDefinition
+metadata:
+  name: unit_testing_job_definition
+spec:
+  jobDefinitionName: !-intentionally-invalid-name
+  jobResources:
+    clusterConfig:
+      instanceCount: 1
+      instanceType: ml.m5.large
+      volumeSizeInGB: 20
+  dataQualityAppSpecification:
+    imageURI: 159807026194.dkr.ecr.us-west-2.amazonaws.com
+    postAnalyticsProcessorSourceURI: "s3://source-data-bucket-592697580195-us-west-2/sagemaker/data_quality_job_definition/code/postprocessor.py"
+  dataQualityBaselineConfig:
+    constraintsResource:
+      s3URI: "s3://source-data-bucket-592697580195-us-west-2/sagemaker/data_quality_job_definition/baselining/constraints.json"
+    statisticsResource:
+      s3URI: "s3://source-data-bucket-592697580195-us-west-2/sagemaker/data_quality_job_definition/baselining/statistics.json"
+  dataQualityJobInput:
+    endpointInput:
+      endpointName: unit_testing_endpoint
+      localPath: "/opt/ml/processing/input/endpoint"
+      s3InputMode: File
+      s3DataDistributionType: FullyReplicated
+  dataQualityJobOutputConfig:
+    monitoringOutputs:
+    - s3Output:
+        localPath: "/opt/ml/processing/output"
+        s3URI: "s3://source-data-bucket-592697580195-us-west-2/sagemaker/data_quality_job_definition/reports"
+        s3UploadMode: Continuous
+  stoppingCondition:
+    maxRuntimeInSeconds: 1800
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  tags:
+    - key: confidentiality
+      value: public
+    - key: environment
+      value: testing
+    - key: customer
+      value: test-user

--- a/pkg/resource/data_quality_job_definition/testdata/data_quality_job_definition/v1alpha1/dqjd_invalid_create_attempted.yaml
+++ b/pkg/resource/data_quality_job_definition/testdata/data_quality_job_definition/v1alpha1/dqjd_invalid_create_attempted.yaml
@@ -1,0 +1,49 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: DataQualityJobDefinition
+metadata:
+  creationTimestamp: null
+  name: unit_testing_job_definition
+spec:
+  dataQualityAppSpecification:
+    imageURI: 159807026194.dkr.ecr.us-west-2.amazonaws.com
+    postAnalyticsProcessorSourceURI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/data_quality_job_definition/code/postprocessor.py
+  dataQualityBaselineConfig:
+    constraintsResource:
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/data_quality_job_definition/baselining/constraints.json
+    statisticsResource:
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/data_quality_job_definition/baselining/statistics.json
+  dataQualityJobInput:
+    endpointInput:
+      endpointName: unit_testing_endpoint
+      localPath: /opt/ml/processing/input/endpoint
+      s3DataDistributionType: FullyReplicated
+      s3InputMode: File
+  dataQualityJobOutputConfig:
+    monitoringOutputs:
+    - s3Output:
+        localPath: /opt/ml/processing/output
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/data_quality_job_definition/reports
+        s3UploadMode: Continuous
+  jobDefinitionName: ""
+  jobResources:
+    clusterConfig:
+      instanceCount: 1
+      instanceType: ml.m5.large
+      volumeSizeInGB: 20
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  stoppingCondition:
+    maxRuntimeInSeconds: 1800
+  tags:
+  - key: confidentiality
+    value: public
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: The job definition name must start with an alphanumeric character.
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/data_quality_job_definition/testdata/test_suite.yaml
+++ b/pkg/resource/data_quality_job_definition/testdata/test_suite.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: "Data quality job definition create tests"
+    description: "Part of data quality job definition CRD tests."
+    scenarios:
+     - name: "Create=InvalidInput"
+       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+       given:
+         desired_state: "data_quality_job_definition/v1alpha1/dqjd_invalid_before_create.yaml"
+         svc_api:
+           - operation: CreateDataQualityJobDefinitionWithContext
+             error:
+               code: InvalidParameterValue
+               message: "The job definition name must start with an alphanumeric character."
+       invoke: Create
+       expect:
+         latest_state: "data_quality_job_definition/v1alpha1/dqjd_invalid_create_attempted.yaml"
+         error: resource is in terminal condition

--- a/pkg/resource/endpoint/manager_test_suite_test.go
+++ b/pkg/resource/endpoint/manager_test_suite_test.go
@@ -11,15 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package feature_group
+package endpoint
 
 import (
 	"errors"
 	"fmt"
-
+	
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/ghodss/yaml"
-	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
@@ -35,24 +35,24 @@ import (
 // provideResourceManagerWithMockSDKAPI accepts MockSageMakerAPI and returns pointer to resourceManager
 // the returned resourceManager is configured to use mockapi api.
 func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMakerAPI) *resourceManager {
-     zapOptions := ctrlrtzap.Options{
-     	    Development: true,
-	    Level:       zapcore.InfoLevel,
-     }
-     fakeLogger := ctrlrtzap.New(ctrlrtzap.UseFlagOptions(&zapOptions))
-     return &resourceManager{
-     	    rr:           nil,
-	    awsAccountID: "",
-	    awsRegion:    "",
-	    sess:         nil,
-	    sdkapi:       mockSageMakerAPI,
-	    log:          fakeLogger,
-	    metrics:      ackmetrics.NewMetrics("sagemaker"),
-     }
+	zapOptions := ctrlrtzap.Options{
+		Development: true,
+		Level:       zapcore.InfoLevel,
+	}
+	fakeLogger := ctrlrtzap.New(ctrlrtzap.UseFlagOptions(&zapOptions))
+	return &resourceManager{
+		rr:           nil,
+		awsAccountID: "",
+		awsRegion:    "",
+		sess:         nil,
+		sdkapi:       mockSageMakerAPI,
+		log:          fakeLogger,
+		metrics:      ackmetrics.NewMetrics("sagemaker"),
+	}
 }
 
-// TestFeatureGroupTestSuite runs the test suite for feature group
-func TestFeatureGroupTestSuite(t *testing.T) {
+// TestEndpointTestSuite runs the test suite for endpoint
+func TestEndpointTestSuite(t *testing.T) {
      	defer func() {
      	   if r := recover(); r != nil {
      	      fmt.Println(testutil.RecoverPanicString, r)
@@ -89,14 +89,17 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	}
 	//TODO: use reflection, template to auto generate this block/method.
 	switch apiName {
-	case "CreateFeatureGroupWithContext":
-		var output svcsdk.CreateFeatureGroupOutput
+	case "CreateEndpointWithContext":
+		var output svcsdk.CreateEndpointOutput
+	    	return &output, nil
+	case "DeleteEndpointWithContext":
+		var output svcsdk.DeleteEndpointOutput
 		return &output, nil
-	case "DeleteFeatureGroupWithContext":
-		var output svcsdk.DeleteFeatureGroupOutput
+	case "DescribeEndpointWithContext":
+		var output svcsdk.DescribeEndpointOutput
 		return &output, nil
-	case "DescribeFeatureGroupWithContext":
-		var output svcsdk.DescribeFeatureGroupOutput
+	case "UpdateEndpointWithContext":
+		var output svcsdk.UpdateEndpointOutput
 		return &output, nil
 	}
 	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))

--- a/pkg/resource/endpoint/testdata/endpoint/v1alpha1/e_invalid_before_create.yaml
+++ b/pkg/resource/endpoint/testdata/endpoint/v1alpha1/e_invalid_before_create.yaml
@@ -1,0 +1,14 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: Endpoint
+metadata:
+  name: unit_testing_endpoint
+spec:
+  endpointName: !-intentionally-invalid-name
+  endpointConfigName: unit_testing_endpoint
+  tags:
+    - key: confidentiality
+      value: public
+    - key: environment
+      value: testing
+    - key: customer
+      value: test-user

--- a/pkg/resource/endpoint/testdata/endpoint/v1alpha1/e_invalid_create_attempted.yaml
+++ b/pkg/resource/endpoint/testdata/endpoint/v1alpha1/e_invalid_create_attempted.yaml
@@ -1,0 +1,22 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: Endpoint
+metadata:
+  creationTimestamp: null
+  name: unit_testing_endpoint
+spec:
+  endpointConfigName: unit_testing_endpoint
+  endpointName: ""
+  tags:
+  - key: confidentiality
+    value: public
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: The endpoint name must start with an alphanumeric character.
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/endpoint/testdata/test_suite.yaml
+++ b/pkg/resource/endpoint/testdata/test_suite.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: "Endpoint create tests"
+    description: "Part of Endpoint CRUD tests."
+    scenarios:
+     - name: "Create=InvalidInput"
+       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+       given:
+         desired_state: "endpoint/v1alpha1/e_invalid_before_create.yaml"
+         svc_api:
+           - operation: CreateEndpointWithContext
+             error:
+               code: InvalidParameterValue
+               message: "The endpoint name must start with an alphanumeric character."
+       invoke: Create
+       expect:
+         latest_state: "endpoint/v1alpha1/e_invalid_create_attempted.yaml"
+         error: resource is in terminal condition

--- a/pkg/resource/endpoint_config/manager_test_suite_test.go
+++ b/pkg/resource/endpoint_config/manager_test_suite_test.go
@@ -11,15 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package feature_group
+package endpoint_config
 
 import (
 	"errors"
 	"fmt"
 
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/ghodss/yaml"
-	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
@@ -51,14 +51,8 @@ func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMa
      }
 }
 
-// TestFeatureGroupTestSuite runs the test suite for feature group
-func TestFeatureGroupTestSuite(t *testing.T) {
-     	defer func() {
-     	   if r := recover(); r != nil {
-     	      fmt.Println(testutil.RecoverPanicString, r)
-	      t.Fail()
-     	   }
-        }()
+// TestEndpointConfigTestSuite runs the test suite for endpoint config.
+func TestEndpointConfigTestSuite(t *testing.T) {
 	var ts = testutil.TestSuite{}
 	testutil.LoadFromFixture(filepath.Join("testdata", "test_suite.yaml"), &ts)
 	var delegate = testRunnerDelegate{t: t}
@@ -89,14 +83,14 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	}
 	//TODO: use reflection, template to auto generate this block/method.
 	switch apiName {
-	case "CreateFeatureGroupWithContext":
-		var output svcsdk.CreateFeatureGroupOutput
+	case "CreateEndpointConfigWithContext":
+		var output svcsdk.CreateEndpointConfigOutput
 		return &output, nil
-	case "DeleteFeatureGroupWithContext":
-		var output svcsdk.DeleteFeatureGroupOutput
+	case "DescribeEndpointConfigWithContext":
+		var output svcsdk.DescribeEndpointConfigOutput
 		return &output, nil
-	case "DescribeFeatureGroupWithContext":
-		var output svcsdk.DescribeFeatureGroupOutput
+	case "DeleteEndpointConfigWithContext":
+		var output svcsdk.DeleteEndpointConfigOutput
 		return &output, nil
 	}
 	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))

--- a/pkg/resource/endpoint_config/testdata/endpoint_config/v1alpha1/ec_invalid_before_create.yaml
+++ b/pkg/resource/endpoint_config/testdata/endpoint_config/v1alpha1/ec_invalid_before_create.yaml
@@ -1,0 +1,21 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: EndpointConfig
+metadata:
+  name: unit-testing-endpoint-config
+  spec:
+    endpointConfigName: !-intentionally-invalid-name
+    productionVariants:
+      - variantName: variant-1
+        modelName: unit-testing-model
+        # instanceCount is 2 to test retainAllVariantProperties
+        initialInstanceCount: 2
+        # This is the smallest instance type which will support scaling
+        instanceType: ml.c5.large
+        initialVariantWeight: 1
+  tags:
+    - key: confidentiality
+      value: public
+    - key: environment
+      value: testing
+    - key: customer
+      value: test-user

--- a/pkg/resource/endpoint_config/testdata/endpoint_config/v1alpha1/ec_invalid_create_attempted.yaml
+++ b/pkg/resource/endpoint_config/testdata/endpoint_config/v1alpha1/ec_invalid_create_attempted.yaml
@@ -1,0 +1,15 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: EndpointConfig
+metadata:
+  creationTimestamp: null
+  name: unit-testing-endpoint-config
+spec:
+  endpointConfigName: null
+  productionVariants: null
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: The endpoint config name must start with an alphanumeric character.
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/endpoint_config/testdata/test_suite.yaml
+++ b/pkg/resource/endpoint_config/testdata/test_suite.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: "Endpoint config create tests"
+    description: "Part of endpoint config CRD tests."
+    scenarios:
+     - name: "Create=InvalidInput"
+       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+       given:
+         desired_state: "endpoint_config/v1alpha1/ec_invalid_before_create.yaml"
+         svc_api:
+           - operation: CreateEndpointConfigWithContext
+             error:
+               code: InvalidParameterValue
+               message: "The endpoint config name must start with an alphanumeric character."
+       invoke: Create
+       expect:
+         latest_state: "endpoint_config/v1alpha1/ec_invalid_create_attempted.yaml"
+         error: resource is in terminal condition

--- a/pkg/resource/hyper_parameter_tuning_job/manager_test_suite_test.go
+++ b/pkg/resource/hyper_parameter_tuning_job/manager_test_suite_test.go
@@ -11,15 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package feature_group
+package hyper_parameter_tuning_job
 
 import (
 	"errors"
 	"fmt"
 
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/ghodss/yaml"
-	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
@@ -51,14 +51,8 @@ func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMa
      }
 }
 
-// TestFeatureGroupTestSuite runs the test suite for feature group
-func TestFeatureGroupTestSuite(t *testing.T) {
-     	defer func() {
-     	   if r := recover(); r != nil {
-     	      fmt.Println(testutil.RecoverPanicString, r)
-	      t.Fail()
-     	   }
-        }()
+// TestHyperParameterTuningJobTestSuite runs the test suite for hyper parameter tuning job.
+func TestHyperParameterTuningJobTestSuite(t *testing.T) {
 	var ts = testutil.TestSuite{}
 	testutil.LoadFromFixture(filepath.Join("testdata", "test_suite.yaml"), &ts)
 	var delegate = testRunnerDelegate{t: t}
@@ -89,14 +83,14 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	}
 	//TODO: use reflection, template to auto generate this block/method.
 	switch apiName {
-	case "CreateFeatureGroupWithContext":
-		var output svcsdk.CreateFeatureGroupOutput
+	case "CreateHyperParameterTuningJobWithContext":
+		var output svcsdk.CreateHyperParameterTuningJobOutput
 		return &output, nil
-	case "DeleteFeatureGroupWithContext":
-		var output svcsdk.DeleteFeatureGroupOutput
+	case "DescribeHyperParameterTuningJobWithContext":
+		var output svcsdk.DescribeHyperParameterTuningJobOutput
 		return &output, nil
-	case "DescribeFeatureGroupWithContext":
-		var output svcsdk.DescribeFeatureGroupOutput
+	case "StopHyperParameterTuningJobWithContext":
+		var output svcsdk.StopHyperParameterTuningJobOutput
 		return &output, nil
 	}
 	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))

--- a/pkg/resource/hyper_parameter_tuning_job/testdata/hyper_parameter_tuning_job/v1alpha1/hptj_invalid_before_create.yaml
+++ b/pkg/resource/hyper_parameter_tuning_job/testdata/hyper_parameter_tuning_job/v1alpha1/hptj_invalid_before_create.yaml
@@ -1,0 +1,68 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: HyperParameterTuningJob
+metadata:
+  name: unit-testing-hyper-parameter-tuning-job
+spec:
+  hyperParameterTuningJobName: !-intentionally-invalid-name
+  hyperParameterTuningJobConfig:
+    strategy: Bayesian
+    hyperParameterTuningJobObjective:
+      type_: Minimize
+      metricName: validation:error
+    resourceLimits:
+      maxNumberOfTrainingJobs: 2
+      maxParallelTrainingJobs: 1
+    parameterRanges:
+      integerParameterRanges:
+      - name: num_round
+        minValue: '10'
+        maxValue: '20'
+        scalingType: Linear
+      continuousParameterRanges: []
+      categoricalParameterRanges: []
+    trainingJobEarlyStoppingType: Auto
+  trainingJobDefinition:
+    staticHyperParameters:
+      base_score: '0.5'
+    algorithmSpecification:
+      trainingImage: 246618743249.dkr.ecr.us-west-2.amazonaws.com
+      trainingInputMode: File
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  inputDataConfig:
+  - channelName: train
+    dataSource:
+      s3DataSource:
+        s3DataType: S3Prefix
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/training/train
+        s3DataDistributionType: FullyReplicated
+    contentType: text/csv
+    compressionType: None
+    recordWrapperType: None
+    inputMode: File
+  - channelName: validation
+    dataSource:
+      s3DataSource:
+        s3DataType: S3Prefix
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/training/validation/
+        s3DataDistributionType: FullyReplicated
+    contentType: text/csv
+    compressionType: None
+    recordWrapperType: None
+    inputMode: File
+  outputDataConfig:
+    s3OutputPath: s3://source-data-bucket-592697580195-us-west-2/sagemaker/hpo/output
+  resourceConfig:
+    instanceType: ml.m5.large
+    instanceCount: 1
+    volumeSizeInGB: 25
+  stoppingCondition:
+    maxRuntimeInSeconds: 3600
+  enableNetworkIsolation: true
+  enableInterContainerTrafficEncryption: false
+tags:
+  - key: algorithm
+    value: xgboost
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user

--- a/pkg/resource/hyper_parameter_tuning_job/testdata/hyper_parameter_tuning_job/v1alpha1/hptj_invalid_create_attempted.yaml
+++ b/pkg/resource/hyper_parameter_tuning_job/testdata/hyper_parameter_tuning_job/v1alpha1/hptj_invalid_create_attempted.yaml
@@ -1,0 +1,35 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: HyperParameterTuningJob
+metadata:
+  creationTimestamp: null
+  name: unit-testing-hyper-parameter-tuning-job
+spec:
+  hyperParameterTuningJobConfig:
+    hyperParameterTuningJobObjective:
+      metricName: validation:error
+      type_: Minimize
+    parameterRanges:
+      integerParameterRanges:
+      - maxValue: "20"
+        minValue: "10"
+        name: num_round
+        scalingType: Linear
+    resourceLimits:
+      maxNumberOfTrainingJobs: 2
+      maxParallelTrainingJobs: 1
+    strategy: Bayesian
+    trainingJobEarlyStoppingType: Auto
+  hyperParameterTuningJobName: ""
+  trainingJobDefinition:
+    algorithmSpecification:
+      trainingImage: 246618743249.dkr.ecr.us-west-2.amazonaws.com
+      trainingInputMode: File
+    staticHyperParameters:
+      base_score: "0.5"
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: The hyper parameter tuning job name must start with an alphanumeric character.
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/hyper_parameter_tuning_job/testdata/test_suite.yaml
+++ b/pkg/resource/hyper_parameter_tuning_job/testdata/test_suite.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: "Hyper parameter tuning job create tests"
+    description: "Part of hyper parameter tuning job CRD tests."
+    scenarios:
+     - name: "Create=InvalidInput"
+       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+       given:
+         desired_state: "hyper_parameter_tuning_job/v1alpha1/hptj_invalid_before_create.yaml"
+         svc_api:
+           - operation: CreateHyperParameterTuningJobWithContext
+             error:
+               code: InvalidParameterValue
+               message: "The hyper parameter tuning job name must start with an alphanumeric character."
+       invoke: Create
+       expect:
+         latest_state: "hyper_parameter_tuning_job/v1alpha1/hptj_invalid_create_attempted.yaml"
+         error: resource is in terminal condition

--- a/pkg/resource/model/manager_test_suite_test.go
+++ b/pkg/resource/model/manager_test_suite_test.go
@@ -11,15 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package feature_group
+package model
 
 import (
 	"errors"
 	"fmt"
 
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/ghodss/yaml"
-	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
@@ -51,14 +51,8 @@ func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMa
      }
 }
 
-// TestFeatureGroupTestSuite runs the test suite for feature group
-func TestFeatureGroupTestSuite(t *testing.T) {
-     	defer func() {
-     	   if r := recover(); r != nil {
-     	      fmt.Println(testutil.RecoverPanicString, r)
-	      t.Fail()
-     	   }
-        }()
+// TestModelTestSuite runs the test suite for model
+func TestModelTestSuite(t *testing.T) {
 	var ts = testutil.TestSuite{}
 	testutil.LoadFromFixture(filepath.Join("testdata", "test_suite.yaml"), &ts)
 	var delegate = testRunnerDelegate{t: t}
@@ -89,14 +83,14 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	}
 	//TODO: use reflection, template to auto generate this block/method.
 	switch apiName {
-	case "CreateFeatureGroupWithContext":
-		var output svcsdk.CreateFeatureGroupOutput
+	case "CreateModelWithContext":
+		var output svcsdk.CreateModelOutput
 		return &output, nil
-	case "DeleteFeatureGroupWithContext":
-		var output svcsdk.DeleteFeatureGroupOutput
+	case "DescribeModelWithContext":
+		var output svcsdk.DescribeModelOutput
 		return &output, nil
-	case "DescribeFeatureGroupWithContext":
-		var output svcsdk.DescribeFeatureGroupOutput
+	case "DeleteModelWithContext":
+		var output svcsdk.DeleteModelOutput
 		return &output, nil
 	}
 	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))

--- a/pkg/resource/model/testdata/model/v1alpha1/m_invalid_before_create.yaml
+++ b/pkg/resource/model/testdata/model/v1alpha1/m_invalid_before_create.yaml
@@ -1,0 +1,21 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: Model
+metadata:
+  name: unit-testing-model
+spec:
+  modelName: !-intentionally-invalid-name
+  primaryContainer:
+    containerHostname: xgboost
+    modelDataURL: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model/xgboost-mnist-model.tar.gz
+    image: 433757028032.dkr.ecr.us-west-2.amazonaws.com
+    environment:
+      my_var: my_value
+      my_var2: my_value2
+  executionRoleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  tags:
+    - key: algorithm
+      value: xgboost
+    - key: environment
+      value: testing
+    - key: customer
+      value: test-user

--- a/pkg/resource/model/testdata/model/v1alpha1/m_invalid_create_attempted.yaml
+++ b/pkg/resource/model/testdata/model/v1alpha1/m_invalid_create_attempted.yaml
@@ -1,0 +1,29 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: Model
+metadata:
+  creationTimestamp: null
+  name: unit-testing-model
+spec:
+  executionRoleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  modelName: ""
+  primaryContainer:
+    containerHostname: xgboost
+    environment:
+      my_var: my_value
+      my_var2: my_value2
+    image: 433757028032.dkr.ecr.us-west-2.amazonaws.com
+    modelDataURL: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model/xgboost-mnist-model.tar.gz
+  tags:
+  - key: algorithm
+    value: xgboost
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: The model name must start with an alphanumeric character.
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/model/testdata/test_suite.yaml
+++ b/pkg/resource/model/testdata/test_suite.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: "Model create tests"
+    description: "Part of model CRD tests."
+    scenarios:
+     - name: "Create=InvalidInput"
+       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+       given:
+         desired_state: "model/v1alpha1/m_invalid_before_create.yaml"
+         svc_api:
+           - operation: CreateModelWithContext
+             error:
+               code: InvalidParameterValue
+               message: "The model name must start with an alphanumeric character."
+       invoke: Create
+       expect:
+         latest_state: "model/v1alpha1/m_invalid_create_attempted.yaml"
+         error: resource is in terminal condition

--- a/pkg/resource/model_bias_job_definition/manager_test_suite_test.go
+++ b/pkg/resource/model_bias_job_definition/manager_test_suite_test.go
@@ -11,15 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package feature_group
+package model_bias_job_definition
 
 import (
 	"errors"
 	"fmt"
 
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/ghodss/yaml"
-	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
@@ -51,14 +51,8 @@ func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMa
      }
 }
 
-// TestFeatureGroupTestSuite runs the test suite for feature group
-func TestFeatureGroupTestSuite(t *testing.T) {
-     	defer func() {
-     	   if r := recover(); r != nil {
-     	      fmt.Println(testutil.RecoverPanicString, r)
-	      t.Fail()
-     	   }
-        }()
+// TestModelBiasJobDefinitionTestSuite runs the test suite for model bias job definition
+func TestModelBiasJobDefinitionTestSuite(t *testing.T) {
 	var ts = testutil.TestSuite{}
 	testutil.LoadFromFixture(filepath.Join("testdata", "test_suite.yaml"), &ts)
 	var delegate = testRunnerDelegate{t: t}
@@ -89,14 +83,14 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	}
 	//TODO: use reflection, template to auto generate this block/method.
 	switch apiName {
-	case "CreateFeatureGroupWithContext":
-		var output svcsdk.CreateFeatureGroupOutput
+	case "CreateModelBiasJobDefinitionWithContext":
+		var output svcsdk.CreateModelBiasJobDefinitionOutput
 		return &output, nil
-	case "DeleteFeatureGroupWithContext":
-		var output svcsdk.DeleteFeatureGroupOutput
+	case "DescribeModelBiasJobDefinitionWithContext":
+		var output svcsdk.DescribeModelBiasJobDefinitionOutput
 		return &output, nil
-	case "DescribeFeatureGroupWithContext":
-		var output svcsdk.DescribeFeatureGroupOutput
+	case "DeleteModelBiasJobDefinitionWithContext":
+		var output svcsdk.DeleteModelBiasJobDefinitionOutput
 		return &output, nil
 	}
 	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))

--- a/pkg/resource/model_bias_job_definition/testdata/model_bias_job_definition/v1alpha1/mbjd_invalid_before_create.yaml
+++ b/pkg/resource/model_bias_job_definition/testdata/model_bias_job_definition/v1alpha1/mbjd_invalid_before_create.yaml
@@ -1,0 +1,44 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: ModelBiasJobDefinition
+metadata:
+  name: unit-testing-model-bias-job-definition
+spec:
+  jobDefinitionName: !-intentionally-invalid-name 
+  jobResources:
+    clusterConfig:
+      instanceCount: 1
+      instanceType: ml.m5.large
+      volumeSizeInGB: 30
+  modelBiasAppSpecification:
+    imageURI: 306415355426.dkr.ecr.us-west-2.amazonaws.com
+    configURI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_bias_job_definition/baselining/analysis_config.json
+  modelBiasBaselineConfig:
+    constraintsResource:
+      s3URI: "s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_bias_job_definition/baselining/analysis.json"
+  modelBiasJobInput:
+    endpointInput:
+      endpointName: unit-testing-endpoint
+      localPath: "/opt/ml/processing/input/endpoint"
+      s3InputMode: File
+      s3DataDistributionType: FullyReplicated
+      probabilityThresholdAttribute: 0.8
+      startTimeOffset: "-PT1H"
+      endTimeOffset: "-PT0H"
+    groundTruthS3Input:
+      s3URI: "s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_bias_job_definition/ground_truth_data"
+  modelBiasJobOutputConfig:
+    monitoringOutputs:
+    - s3Output:
+      localPath: "/opt/ml/processing/output"
+      s3URI: "s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_bias_job_definition/reports"
+      s3UploadMode: Continuous
+  stoppingCondition:
+    maxRuntimeInSeconds: 1800
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  tags:
+    - key: confidentiality
+      value: public
+    - key: environment
+      value: testing
+    - key: customer
+      value: test-user

--- a/pkg/resource/model_bias_job_definition/testdata/model_bias_job_definition/v1alpha1/mbjd_invalid_create_attempted.yaml
+++ b/pkg/resource/model_bias_job_definition/testdata/model_bias_job_definition/v1alpha1/mbjd_invalid_create_attempted.yaml
@@ -1,0 +1,49 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: ModelBiasJobDefinition
+metadata:
+  creationTimestamp: null
+  name: unit-testing-model-bias-job-definition
+spec:
+  jobDefinitionName: ""
+  jobResources:
+    clusterConfig:
+      instanceCount: 1
+      instanceType: ml.m5.large
+      volumeSizeInGB: 30
+  modelBiasAppSpecification:
+    configURI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_bias_job_definition/baselining/analysis_config.json
+    imageURI: 306415355426.dkr.ecr.us-west-2.amazonaws.com
+  modelBiasBaselineConfig:
+    constraintsResource:
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_bias_job_definition/baselining/analysis.json
+  modelBiasJobInput:
+    endpointInput:
+      endTimeOffset: -PT0H
+      endpointName: unit-testing-endpoint
+      localPath: /opt/ml/processing/input/endpoint
+      probabilityThresholdAttribute: 0.8
+      s3DataDistributionType: FullyReplicated
+      s3InputMode: File
+      startTimeOffset: -PT1H
+    groundTruthS3Input:
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_bias_job_definition/ground_truth_data
+  modelBiasJobOutputConfig:
+    monitoringOutputs:
+    - {}
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  stoppingCondition:
+    maxRuntimeInSeconds: 1800
+  tags:
+  - key: confidentiality
+    value: public
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: The job definition name must start with an alphanumeric character.
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/model_bias_job_definition/testdata/test_suite.yaml
+++ b/pkg/resource/model_bias_job_definition/testdata/test_suite.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: "Model bias job definition create tests"
+    description: "Part of model bias job definition CRD tests."
+    scenarios:
+     - name: "Create=InvalidInput"
+       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+       given:
+         desired_state: "model_bias_job_definition/v1alpha1/mbjd_invalid_before_create.yaml"
+         svc_api:
+           - operation: CreateModelBiasJobDefinitionWithContext
+             error:
+               code: InvalidParameterValue
+               message: "The job definition name must start with an alphanumeric character."
+       invoke: Create
+       expect:
+         latest_state: "model_bias_job_definition/v1alpha1/mbjd_invalid_create_attempted.yaml"
+         error: resource is in terminal condition

--- a/pkg/resource/model_explainability_job_definition/manager_test_suite_test.go
+++ b/pkg/resource/model_explainability_job_definition/manager_test_suite_test.go
@@ -11,15 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package feature_group
+package model_explainability_job_definition
 
 import (
 	"errors"
 	"fmt"
 
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/ghodss/yaml"
-	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
@@ -51,14 +51,8 @@ func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMa
      }
 }
 
-// TestFeatureGroupTestSuite runs the test suite for feature group
-func TestFeatureGroupTestSuite(t *testing.T) {
-     	defer func() {
-     	   if r := recover(); r != nil {
-     	      fmt.Println(testutil.RecoverPanicString, r)
-	      t.Fail()
-     	   }
-        }()
+// TestModelExplainabilityJobDefinitionTestSuite runs the test suite for model explainability job definition
+func TestModelExplainabilityJobDefinitionTestSuite(t *testing.T) {
 	var ts = testutil.TestSuite{}
 	testutil.LoadFromFixture(filepath.Join("testdata", "test_suite.yaml"), &ts)
 	var delegate = testRunnerDelegate{t: t}
@@ -89,14 +83,14 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	}
 	//TODO: use reflection, template to auto generate this block/method.
 	switch apiName {
-	case "CreateFeatureGroupWithContext":
-		var output svcsdk.CreateFeatureGroupOutput
+	case "CreateModelExplainabilityJobDefinitionWithContext":
+		var output svcsdk.CreateModelExplainabilityJobDefinitionOutput
 		return &output, nil
-	case "DeleteFeatureGroupWithContext":
-		var output svcsdk.DeleteFeatureGroupOutput
+	case "DescribeModelExplainabilityJobDefinitionWithContext":
+		var output svcsdk.DescribeModelExplainabilityJobDefinitionOutput
 		return &output, nil
-	case "DescribeFeatureGroupWithContext":
-		var output svcsdk.DescribeFeatureGroupOutput
+	case "DeleteModelExplainabilityJobDefinitionWithContext":
+		var output svcsdk.DeleteModelExplainabilityJobDefinitionOutput
 		return &output, nil
 	}
 	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))

--- a/pkg/resource/model_explainability_job_definition/testdata/model_explainability_job_definition/v1alpha1/mejd_invalid_before_create.yaml
+++ b/pkg/resource/model_explainability_job_definition/testdata/model_explainability_job_definition/v1alpha1/mejd_invalid_before_create.yaml
@@ -1,0 +1,39 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: ModelExplainabilityJobDefinition
+metadata:
+  name: unit-testing-model-explainability-job-definition
+spec:
+  jobDefinitionName: !-intentionally-invalid-name
+  jobResources:
+    clusterConfig:
+      instanceCount: 1
+      instanceType: ml.m5.large
+      volumeSizeInGB: 30
+  modelExplainabilityAppSpecification:
+    imageURI: 306415355426.dkr.ecr.us-west-2.amazonaws.com
+    configURI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_explainability_job_definition/baselining/analysis_config.json
+  modelExplainabilityBaselineConfig:
+    constraintsResource:
+      s3URI: "s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_explainability_job_definition/baselining/analysis.json"
+  modelExplainabilityJobInput:
+    endpointInput:
+      endpointName: unit-testing-endpoint
+      localPath: "/opt/ml/processing/input/endpoint"
+      s3InputMode: File
+      s3DataDistributionType: FullyReplicated
+  modelExplainabilityJobOutputConfig:
+    monitoringOutputs:
+    - s3Output:
+        localPath: "/opt/ml/processing/output"
+        s3URI: "s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_explainability_job_definition/reports"
+        s3UploadMode: Continuous
+  stoppingCondition:
+    maxRuntimeInSeconds: 1800
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  tags:
+    - key: confidentiality
+      value: public
+    - key: environment
+      value: testing
+    - key: customer
+      value: test-user

--- a/pkg/resource/model_explainability_job_definition/testdata/model_explainability_job_definition/v1alpha1/mejd_invalid_create_attempted.yaml
+++ b/pkg/resource/model_explainability_job_definition/testdata/model_explainability_job_definition/v1alpha1/mejd_invalid_create_attempted.yaml
@@ -1,0 +1,47 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: ModelExplainabilityJobDefinition
+metadata:
+  creationTimestamp: null
+  name: unit-testing-model-explainability-job-definition
+spec:
+  jobDefinitionName: ""
+  jobResources:
+    clusterConfig:
+      instanceCount: 1
+      instanceType: ml.m5.large
+      volumeSizeInGB: 30
+  modelExplainabilityAppSpecification:
+    configURI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_explainability_job_definition/baselining/analysis_config.json
+    imageURI: 306415355426.dkr.ecr.us-west-2.amazonaws.com
+  modelExplainabilityBaselineConfig:
+    constraintsResource:
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_explainability_job_definition/baselining/analysis.json
+  modelExplainabilityJobInput:
+    endpointInput:
+      endpointName: unit-testing-endpoint
+      localPath: /opt/ml/processing/input/endpoint
+      s3DataDistributionType: FullyReplicated
+      s3InputMode: File
+  modelExplainabilityJobOutputConfig:
+    monitoringOutputs:
+    - s3Output:
+        localPath: /opt/ml/processing/output
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_explainability_job_definition/reports
+        s3UploadMode: Continuous
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  stoppingCondition:
+    maxRuntimeInSeconds: 1800
+  tags:
+  - key: confidentiality
+    value: public
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: The job definition name must start with an alphanumeric character.
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/model_explainability_job_definition/testdata/test_suite.yaml
+++ b/pkg/resource/model_explainability_job_definition/testdata/test_suite.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: "Model explainability job definition create tests"
+    description: "Part of model explainability job definition CRD tests."
+    scenarios:
+     - name: "Create=InvalidInput"
+       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+       given:
+         desired_state: "model_explainability_job_definition/v1alpha1/mejd_invalid_before_create.yaml"
+         svc_api:
+           - operation: CreateModelExplainabilityJobDefinitionWithContext
+             error:
+               code: InvalidParameterValue
+               message: "The job definition name must start with an alphanumeric character."
+       invoke: Create
+       expect:
+         latest_state: "model_explainability_job_definition/v1alpha1/mejd_invalid_create_attempted.yaml"
+         error: resource is in terminal condition

--- a/pkg/resource/model_package/manager_test_suite_test.go
+++ b/pkg/resource/model_package/manager_test_suite_test.go
@@ -11,15 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package feature_group
+package model_package
 
 import (
 	"errors"
 	"fmt"
 
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/ghodss/yaml"
-	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
@@ -51,14 +51,8 @@ func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMa
      }
 }
 
-// TestFeatureGroupTestSuite runs the test suite for feature group
-func TestFeatureGroupTestSuite(t *testing.T) {
-     	defer func() {
-     	   if r := recover(); r != nil {
-     	      fmt.Println(testutil.RecoverPanicString, r)
-	      t.Fail()
-     	   }
-        }()
+// TestModelPackageTestSuite runs the test suite for model package
+func TestModelPackageTestSuite(t *testing.T) {
 	var ts = testutil.TestSuite{}
 	testutil.LoadFromFixture(filepath.Join("testdata", "test_suite.yaml"), &ts)
 	var delegate = testRunnerDelegate{t: t}
@@ -89,14 +83,17 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	}
 	//TODO: use reflection, template to auto generate this block/method.
 	switch apiName {
-	case "CreateFeatureGroupWithContext":
-		var output svcsdk.CreateFeatureGroupOutput
+	case "CreateModelPackageWithContext":
+		var output svcsdk.CreateModelPackageOutput
 		return &output, nil
-	case "DeleteFeatureGroupWithContext":
-		var output svcsdk.DeleteFeatureGroupOutput
+	case "DescribeModelPackageWithContext":
+		var output svcsdk.DescribeModelPackageOutput
 		return &output, nil
-	case "DescribeFeatureGroupWithContext":
-		var output svcsdk.DescribeFeatureGroupOutput
+	case "UpdateModelPackageWithContext":
+		var output svcsdk.UpdateModelPackageOutput
+		return &output, nil
+	case "DeleteModelPackageWithContext":
+		var output svcsdk.DeleteModelPackageOutput
 		return &output, nil
 	}
 	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))

--- a/pkg/resource/model_package/testdata/model_package/v1alpha1/mp_invalid_before_create.yaml
+++ b/pkg/resource/model_package/testdata/model_package/v1alpha1/mp_invalid_before_create.yaml
@@ -1,0 +1,42 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: ModelPackage
+metadata:
+  name: unit-testing-model-package
+spec:
+  modelPackageName: !-intentionally-invalid-name
+  modelPackageDescription: "Description for model package"
+  inferenceSpecification:
+    containers:
+      - image: 433757028032.dkr.ecr.us-west-2.amazonaws.com
+        modelDataURL: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model/xgboost-mnist-model.tar.gz
+    supportedContentTypes:
+      - "text/csv"
+    supportedResponseMIMETypes:
+      - "text/csv"
+    supportedTransformInstanceTypes:
+      - "ml.m5.large"
+    supportedRealtimeInferenceInstanceTypes:
+      - "ml.m5.large"
+  validationSpecification:
+    validationRole: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+    validationProfiles:
+      - profileName: "Test-Model-Package"
+        transformJobDefinition:
+          transformInput:
+            dataSource:
+              s3DataSource:
+                s3DataType: S3Prefix
+                s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/batch/input-data
+            contentType: text/csv
+          transformOutput:
+            s3OutputPath: s3://source-data-bucket-592697580195-us-west-2/sagemaker/batch/output
+          transformResources:
+            instanceCount: 1
+            instanceType: ml.m5.large
+  tags:
+    - key: algorithm
+      value: xgboost
+    - key: environment
+      value: testing
+    - key: customer
+      value: test-user

--- a/pkg/resource/model_package/testdata/model_package/v1alpha1/mp_invalid_create_attempted.yaml
+++ b/pkg/resource/model_package/testdata/model_package/v1alpha1/mp_invalid_create_attempted.yaml
@@ -1,0 +1,50 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: ModelPackage
+metadata:
+  creationTimestamp: null
+  name: unit-testing-model-package
+spec:
+  inferenceSpecification:
+    containers:
+    - image: 433757028032.dkr.ecr.us-west-2.amazonaws.com
+      modelDataURL: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model/xgboost-mnist-model.tar.gz
+    supportedContentTypes:
+    - text/csv
+    supportedRealtimeInferenceInstanceTypes:
+    - ml.m5.large
+    supportedResponseMIMETypes:
+    - text/csv
+    supportedTransformInstanceTypes:
+    - ml.m5.large
+  modelPackageDescription: Description for model package
+  modelPackageName: ""
+  tags:
+  - key: algorithm
+    value: xgboost
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user
+  validationSpecification:
+    validationProfiles:
+    - profileName: Test-Model-Package
+      transformJobDefinition:
+        transformInput:
+          contentType: text/csv
+          dataSource:
+            s3DataSource:
+              s3DataType: S3Prefix
+              s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/batch/input-data
+        transformOutput:
+          s3OutputPath: s3://source-data-bucket-592697580195-us-west-2/sagemaker/batch/output
+        transformResources:
+          instanceCount: 1
+          instanceType: ml.m5.large
+    validationRole: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: The model package name must start with an alphanumeric character.
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/model_package/testdata/test_suite.yaml
+++ b/pkg/resource/model_package/testdata/test_suite.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: "Unversioned model package create tests"
+    description: "Part of unversioned model package CRD tests."
+    scenarios:
+     - name: "Create=InvalidInput"
+       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+       given:
+         desired_state: "model_package/v1alpha1/mp_invalid_before_create.yaml"
+         svc_api:
+           - operation: CreateModelPackageWithContext
+             error:
+               code: InvalidParameterValue
+               message: "The model package name must start with an alphanumeric character."
+       invoke: Create
+       expect:
+         latest_state: "model_package/v1alpha1/mp_invalid_create_attempted.yaml"
+         error: resource is in terminal condition

--- a/pkg/resource/model_package_group/manager_test_suite_test.go
+++ b/pkg/resource/model_package_group/manager_test_suite_test.go
@@ -11,15 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package feature_group
+package model_package_group
 
 import (
 	"errors"
 	"fmt"
 
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/ghodss/yaml"
-	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
@@ -51,14 +51,8 @@ func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMa
      }
 }
 
-// TestFeatureGroupTestSuite runs the test suite for feature group
-func TestFeatureGroupTestSuite(t *testing.T) {
-     	defer func() {
-     	   if r := recover(); r != nil {
-     	      fmt.Println(testutil.RecoverPanicString, r)
-	      t.Fail()
-     	   }
-        }()
+// TestModelPackageGroupTestSuite runs the test suite for model package group
+func TestModelPackageGroupTestSuite(t *testing.T) {
 	var ts = testutil.TestSuite{}
 	testutil.LoadFromFixture(filepath.Join("testdata", "test_suite.yaml"), &ts)
 	var delegate = testRunnerDelegate{t: t}
@@ -89,14 +83,14 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	}
 	//TODO: use reflection, template to auto generate this block/method.
 	switch apiName {
-	case "CreateFeatureGroupWithContext":
-		var output svcsdk.CreateFeatureGroupOutput
+	case "CreateModelPackageGroupWithContext":
+		var output svcsdk.CreateModelPackageGroupOutput
 		return &output, nil
-	case "DeleteFeatureGroupWithContext":
-		var output svcsdk.DeleteFeatureGroupOutput
+	case "DeleteModelPackageGroupWithContext":
+		var output svcsdk.DeleteModelPackageGroupOutput
 		return &output, nil
-	case "DescribeFeatureGroupWithContext":
-		var output svcsdk.DescribeFeatureGroupOutput
+	case "DescribeModelPackageGroupWithContext":
+		var output svcsdk.DescribeModelPackageGroupOutput
 		return &output, nil
 	}
 	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))

--- a/pkg/resource/model_package_group/testdata/model_package_group/v1alpha1/mpg_invalid_before_create.yaml
+++ b/pkg/resource/model_package_group/testdata/model_package_group/v1alpha1/mpg_invalid_before_create.yaml
@@ -1,0 +1,7 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: ModelPackageGroup
+metadata:
+  name: unit-testing-model-package-group
+  spec:
+    modelPackageGroupName: !-intentionally-invalid-name
+      modelPackageGroupDescription: "Description for model package group"

--- a/pkg/resource/model_package_group/testdata/model_package_group/v1alpha1/mpg_invalid_create_attempted.yaml
+++ b/pkg/resource/model_package_group/testdata/model_package_group/v1alpha1/mpg_invalid_create_attempted.yaml
@@ -1,0 +1,14 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: ModelPackageGroup
+metadata:
+  creationTimestamp: null
+  name: unit-testing-model-package-group
+spec:
+  modelPackageGroupName: null
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: The model package group name must start with an alphanumeric character.
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/model_package_group/testdata/test_suite.yaml
+++ b/pkg/resource/model_package_group/testdata/test_suite.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: "Model package group create tests"
+    description: "Part of model package group CRD tests."
+    scenarios:
+     - name: "Create=InvalidInput"
+       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+       given:
+         desired_state: "model_package_group/v1alpha1/mpg_invalid_before_create.yaml"
+         svc_api:
+           - operation: CreateModelPackageGroupWithContext
+             error:
+               code: InvalidParameterValue
+               message: "The model package group name must start with an alphanumeric character."
+       invoke: Create
+       expect:
+         latest_state: "model_package_group/v1alpha1/mpg_invalid_create_attempted.yaml"
+         error: resource is in terminal condition

--- a/pkg/resource/model_quality_job_definition/manager_test_suite_test.go
+++ b/pkg/resource/model_quality_job_definition/manager_test_suite_test.go
@@ -11,15 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package feature_group
+package model_quality_job_definition
 
 import (
 	"errors"
 	"fmt"
 
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/ghodss/yaml"
-	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
@@ -51,14 +51,8 @@ func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMa
      }
 }
 
-// TestFeatureGroupTestSuite runs the test suite for feature group
-func TestFeatureGroupTestSuite(t *testing.T) {
-     	defer func() {
-     	   if r := recover(); r != nil {
-     	      fmt.Println(testutil.RecoverPanicString, r)
-	      t.Fail()
-     	   }
-        }()
+// TestModelQualityJobDefinitionTestSuite runs the test suite for model quality job definition
+func TestModelQualityJobDefinitionTestSuite(t *testing.T) {
 	var ts = testutil.TestSuite{}
 	testutil.LoadFromFixture(filepath.Join("testdata", "test_suite.yaml"), &ts)
 	var delegate = testRunnerDelegate{t: t}
@@ -89,14 +83,14 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	}
 	//TODO: use reflection, template to auto generate this block/method.
 	switch apiName {
-	case "CreateFeatureGroupWithContext":
-		var output svcsdk.CreateFeatureGroupOutput
+	case "CreateModelQualityJobDefinitionWithContext":
+		var output svcsdk.CreateModelQualityJobDefinitionOutput
 		return &output, nil
-	case "DeleteFeatureGroupWithContext":
-		var output svcsdk.DeleteFeatureGroupOutput
+	case "DescribeModelQualityJobDefinitionWithContext":
+		var output svcsdk.DescribeModelQualityJobDefinitionOutput
 		return &output, nil
-	case "DescribeFeatureGroupWithContext":
-		var output svcsdk.DescribeFeatureGroupOutput
+	case "DeleteModelQualityJobDefinitionWithContext":
+		var output svcsdk.DeleteModelQualityJobDefinitionOutput
 		return &output, nil
 	}
 	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))

--- a/pkg/resource/model_quality_job_definition/testdata/model_quality_job_definition/v1alpha1/mqjd_invalid_before_create.yaml
+++ b/pkg/resource/model_quality_job_definition/testdata/model_quality_job_definition/v1alpha1/mqjd_invalid_before_create.yaml
@@ -1,0 +1,43 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: ModelQualityJobDefinition
+metadata:
+  name: unit-testing-model-quality-job-definition
+spec:
+  jobDefinitionName: !-intentionally-invalid-name
+  jobResources:
+    clusterConfig:
+      instanceCount: 1
+      instanceType: ml.m5.large
+      volumeSizeInGB: 20
+  modelQualityAppSpecification:
+    imageURI: 159807026194.dkr.ecr.us-west-2.amazonaws.com
+    problemType: BinaryClassification
+  modelQualityBaselineConfig:
+    constraintsResource:
+      s3URI: "s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_quality_job_definition/baselining/constraints.json"
+  modelQualityJobInput:
+    endpointInput:
+      endpointName: unit-testing-endpoint
+      localPath: "/opt/ml/processing/input_data"
+      s3InputMode: File
+      s3DataDistributionType: FullyReplicated
+      probabilityThresholdAttribute: 0.5
+      probabilityAttribute: "0"
+    groundTruthS3Input:
+      s3URI: "s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_quality_job_definition/ground_truth_data"
+  modelQualityJobOutputConfig:
+    monitoringOutputs:
+    - s3Output:
+        localPath: "/opt/ml/processing/output"
+        s3URI: "s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_quality_job_definition/results"
+        s3UploadMode: Continuous
+  stoppingCondition:
+    maxRuntimeInSeconds: 1800
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  tags:
+    - key: confidentiality
+      value: public
+    - key: environment
+      value: testing
+    - key: customer
+      value: test-user

--- a/pkg/resource/model_quality_job_definition/testdata/model_quality_job_definition/v1alpha1/mqjd_invalid_create_attempted.yaml
+++ b/pkg/resource/model_quality_job_definition/testdata/model_quality_job_definition/v1alpha1/mqjd_invalid_create_attempted.yaml
@@ -1,0 +1,51 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: ModelQualityJobDefinition
+metadata:
+  creationTimestamp: null
+  name: unit-testing-model-quality-job-definition
+spec:
+  jobDefinitionName: ""
+  jobResources:
+    clusterConfig:
+      instanceCount: 1
+      instanceType: ml.m5.large
+      volumeSizeInGB: 20
+  modelQualityAppSpecification:
+    imageURI: 159807026194.dkr.ecr.us-west-2.amazonaws.com
+    problemType: BinaryClassification
+  modelQualityBaselineConfig:
+    constraintsResource:
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_quality_job_definition/baselining/constraints.json
+  modelQualityJobInput:
+    endpointInput:
+      endpointName: unit-testing-endpoint
+      localPath: /opt/ml/processing/input_data
+      probabilityAttribute: "0"
+      probabilityThresholdAttribute: 0.5
+      s3DataDistributionType: FullyReplicated
+      s3InputMode: File
+    groundTruthS3Input:
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_quality_job_definition/ground_truth_data
+  modelQualityJobOutputConfig:
+    monitoringOutputs:
+    - s3Output:
+        localPath: /opt/ml/processing/output
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model_quality_job_definition/results
+        s3UploadMode: Continuous
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  stoppingCondition:
+    maxRuntimeInSeconds: 1800
+  tags:
+  - key: confidentiality
+    value: public
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: The job definition name must start with an alphanumeric character.
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/model_quality_job_definition/testdata/test_suite.yaml
+++ b/pkg/resource/model_quality_job_definition/testdata/test_suite.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: "Model quality job definition create tests"
+    description: "Part of model quality job definition CRD tests."
+    scenarios:
+     - name: "Create=InvalidInput"
+       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+       given:
+         desired_state: "model_quality_job_definition/v1alpha1/mqjd_invalid_before_create.yaml"
+         svc_api:
+           - operation: CreateModelQualityJobDefinitionWithContext
+             error:
+               code: InvalidParameterValue
+               message: "The job definition name must start with an alphanumeric character."
+       invoke: Create
+       expect:
+         latest_state: "model_quality_job_definition/v1alpha1/mqjd_invalid_create_attempted.yaml"
+         error: resource is in terminal condition

--- a/pkg/resource/monitoring_schedule/manager_test_suite_test.go
+++ b/pkg/resource/monitoring_schedule/manager_test_suite_test.go
@@ -11,15 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package feature_group
+package monitoring_schedule
 
 import (
 	"errors"
 	"fmt"
 
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/ghodss/yaml"
-	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
@@ -51,14 +51,8 @@ func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMa
      }
 }
 
-// TestFeatureGroupTestSuite runs the test suite for feature group
-func TestFeatureGroupTestSuite(t *testing.T) {
-     	defer func() {
-     	   if r := recover(); r != nil {
-     	      fmt.Println(testutil.RecoverPanicString, r)
-	      t.Fail()
-     	   }
-        }()
+// TestMonitoringScheduleTestSuite runs the test suite for monitoring schedule
+func TestMonitoringScheduleTestSuite(t *testing.T) {
 	var ts = testutil.TestSuite{}
 	testutil.LoadFromFixture(filepath.Join("testdata", "test_suite.yaml"), &ts)
 	var delegate = testRunnerDelegate{t: t}
@@ -89,14 +83,17 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	}
 	//TODO: use reflection, template to auto generate this block/method.
 	switch apiName {
-	case "CreateFeatureGroupWithContext":
-		var output svcsdk.CreateFeatureGroupOutput
+	case "CreateMonitoringScheduleWithContext":
+		var output svcsdk.CreateMonitoringScheduleOutput
 		return &output, nil
-	case "DeleteFeatureGroupWithContext":
-		var output svcsdk.DeleteFeatureGroupOutput
+	case "DescribeMonitoringScheduleWithContext":
+		var output svcsdk.DescribeMonitoringScheduleOutput
 		return &output, nil
-	case "DescribeFeatureGroupWithContext":
-		var output svcsdk.DescribeFeatureGroupOutput
+	case "UpdateMonitoringScheduleWithContext":
+		var output svcsdk.UpdateMonitoringScheduleOutput
+		return &output, nil
+	case "DeleteMonitoringScheduleWithContext":
+		var output svcsdk.DeleteMonitoringScheduleOutput
 		return &output, nil
 	}
 	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))

--- a/pkg/resource/monitoring_schedule/testdata/monitoring_schedule/v1alpha1/ms_invalid_before_create.yaml
+++ b/pkg/resource/monitoring_schedule/testdata/monitoring_schedule/v1alpha1/ms_invalid_before_create.yaml
@@ -1,0 +1,18 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: MonitoringSchedule
+metadata:
+  name: unit-testing-monitoring-schedule
+spec:
+  monitoringScheduleName: !-intentionally-invalid-name
+  monitoringScheduleConfig:
+    monitoringType: DataQuality
+    monitoringJobDefinitionName: unit-testing-monitoring-job-definition
+    scheduleConfig:
+      scheduleExpression: "cron(0 * ? * * *)"
+  tags:
+    - key: confidentiality
+      value: public
+    - key: environment
+      value: testing
+    - key: customer
+      value: test-user

--- a/pkg/resource/monitoring_schedule/testdata/monitoring_schedule/v1alpha1/ms_invalid_create_attempted.yaml
+++ b/pkg/resource/monitoring_schedule/testdata/monitoring_schedule/v1alpha1/ms_invalid_create_attempted.yaml
@@ -1,0 +1,26 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: MonitoringSchedule
+metadata:
+  creationTimestamp: null
+  name: unit-testing-monitoring-schedule
+spec:
+  monitoringScheduleConfig:
+    monitoringJobDefinitionName: unit-testing-monitoring-job-definition
+    monitoringType: DataQuality
+    scheduleConfig:
+      scheduleExpression: cron(0 * ? * * *)
+  monitoringScheduleName: ""
+  tags:
+  - key: confidentiality
+    value: public
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: The monitoring schedule name must start with an alphanumeric character.
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/monitoring_schedule/testdata/test_suite.yaml
+++ b/pkg/resource/monitoring_schedule/testdata/test_suite.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: "Monitoring schedule create tests"
+    description: "Part of monitoring schedule CRUD tests."
+    scenarios:
+     - name: "Create=InvalidInput"
+       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+       given:
+         desired_state: "monitoring_schedule/v1alpha1/ms_invalid_before_create.yaml"
+         svc_api:
+           - operation: CreateMonitoringScheduleWithContext
+             error:
+               code: InvalidParameterValue
+               message: "The monitoring schedule name must start with an alphanumeric character."
+       invoke: Create
+       expect:
+         latest_state: "monitoring_schedule/v1alpha1/ms_invalid_create_attempted.yaml"
+         error: resource is in terminal condition

--- a/pkg/resource/processing_job/manager_test_suite_test.go
+++ b/pkg/resource/processing_job/manager_test_suite_test.go
@@ -11,15 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package feature_group
+package processing_job
 
 import (
 	"errors"
 	"fmt"
 
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/ghodss/yaml"
-	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
@@ -51,14 +51,8 @@ func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMa
      }
 }
 
-// TestFeatureGroupTestSuite runs the test suite for feature group
-func TestFeatureGroupTestSuite(t *testing.T) {
-     	defer func() {
-     	   if r := recover(); r != nil {
-     	      fmt.Println(testutil.RecoverPanicString, r)
-	      t.Fail()
-     	   }
-        }()
+// TestProcessingJobTestSuite runs the test suite for processing job
+func TestProcessingJobTestSuite(t *testing.T) {
 	var ts = testutil.TestSuite{}
 	testutil.LoadFromFixture(filepath.Join("testdata", "test_suite.yaml"), &ts)
 	var delegate = testRunnerDelegate{t: t}
@@ -89,14 +83,14 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	}
 	//TODO: use reflection, template to auto generate this block/method.
 	switch apiName {
-	case "CreateFeatureGroupWithContext":
-		var output svcsdk.CreateFeatureGroupOutput
+	case "CreateProcessingJobWithContext":
+		var output svcsdk.CreateProcessingJobOutput
 		return &output, nil
-	case "DeleteFeatureGroupWithContext":
-		var output svcsdk.DeleteFeatureGroupOutput
+	case "DescribeProcessingJobWithContext":
+		var output svcsdk.DescribeProcessingJobOutput
 		return &output, nil
-	case "DescribeFeatureGroupWithContext":
-		var output svcsdk.DescribeFeatureGroupOutput
+	case "StopProcessingJobWithContext":
+		var output svcsdk.StopProcessingJobOutput
 		return &output, nil
 	}
 	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))

--- a/pkg/resource/processing_job/testdata/processing_job/v1alpha1/pj_invalid_before_create.yaml
+++ b/pkg/resource/processing_job/testdata/processing_job/v1alpha1/pj_invalid_before_create.yaml
@@ -1,0 +1,59 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: ProcessingJob
+metadata:
+  name: unit-testing-processing-job
+spec:
+  processingJobName: !-intentionally-invalid-name
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  environment:
+    my_var: my_value
+    my_var2: my_value2
+  appSpecification:
+    imageURI: 763104351884.dkr.ecr.us-west-2.amazonaws.com
+    containerEntrypoint:
+      - python
+      - /opt/ml/processing/code/kmeans_preprocessing.py
+  processingResources:
+    clusterConfig:
+      instanceCount: 1
+      instanceType: "ml.m5.large"
+      volumeSizeInGB: 20
+  processingInputs:
+    - inputName: mnist_tar
+      s3Input:
+        s3URI: s3://sagemaker-sample-data-us-west-2/algorithms/kmeans/mnist/mnist.pkl.gz
+        localPath: /opt/ml/processing/input
+        s3DataType: S3Prefix
+        s3InputMode: File
+        s3CompressionType: None
+    - inputName: source_code
+      s3Input:
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/processing/kmeans_preprocessing.py
+        localPath: /opt/ml/processing/code
+        s3DataType: S3Prefix
+        s3InputMode: File
+        s3CompressionType: None
+  processingOutputConfig:
+    outputs:
+      - outputName: train_data
+        s3Output:
+          s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/processing/output/
+          localPath: /opt/ml/processing/output_train/
+          s3UploadMode: EndOfJob
+      - outputName: test_data
+        s3Output:
+          s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/processing/output/
+          localPath: /opt/ml/processing/output_test/
+          s3UploadMode: EndOfJob
+      - outputName: valid_data
+        s3Output:
+          s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/processing/output/
+          localPath: /opt/ml/processing/output_valid/
+          s3UploadMode: EndOfJob
+  tags:
+    - key: confidentiality
+      value: public
+    - key: environment
+      value: testing
+    - key: customer
+      value: test-user

--- a/pkg/resource/processing_job/testdata/processing_job/v1alpha1/pj_invalid_create_attempted.yaml
+++ b/pkg/resource/processing_job/testdata/processing_job/v1alpha1/pj_invalid_create_attempted.yaml
@@ -1,0 +1,67 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: ProcessingJob
+metadata:
+  creationTimestamp: null
+  name: unit-testing-processing-job
+spec:
+  appSpecification:
+    containerEntrypoint:
+    - python
+    - /opt/ml/processing/code/kmeans_preprocessing.py
+    imageURI: 763104351884.dkr.ecr.us-west-2.amazonaws.com
+  environment:
+    my_var: my_value
+    my_var2: my_value2
+  processingInputs:
+  - inputName: mnist_tar
+    s3Input:
+      localPath: /opt/ml/processing/input
+      s3CompressionType: None
+      s3DataType: S3Prefix
+      s3InputMode: File
+      s3URI: s3://sagemaker-sample-data-us-west-2/algorithms/kmeans/mnist/mnist.pkl.gz
+  - inputName: source_code
+    s3Input:
+      localPath: /opt/ml/processing/code
+      s3CompressionType: None
+      s3DataType: S3Prefix
+      s3InputMode: File
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/processing/kmeans_preprocessing.py
+  processingJobName: ""
+  processingOutputConfig:
+    outputs:
+    - outputName: train_data
+      s3Output:
+        localPath: /opt/ml/processing/output_train/
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/processing/output/
+        s3UploadMode: EndOfJob
+    - outputName: test_data
+      s3Output:
+        localPath: /opt/ml/processing/output_test/
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/processing/output/
+        s3UploadMode: EndOfJob
+    - outputName: valid_data
+      s3Output:
+        localPath: /opt/ml/processing/output_valid/
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/processing/output/
+        s3UploadMode: EndOfJob
+  processingResources:
+    clusterConfig:
+      instanceCount: 1
+      instanceType: ml.m5.large
+      volumeSizeInGB: 20
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  tags:
+  - key: confidentiality
+    value: public
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: The processing job name must start with an alphanumeric character.
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/processing_job/testdata/test_suite.yaml
+++ b/pkg/resource/processing_job/testdata/test_suite.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: "Processing job create tests"
+    description: "Part of processing job CRD tests."
+    scenarios:
+     - name: "Create=InvalidInput"
+       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+       given:
+         desired_state: "processing_job/v1alpha1/pj_invalid_before_create.yaml"
+         svc_api:
+           - operation: CreateProcessingJobWithContext
+             error:
+               code: InvalidParameterValue
+               message: "The processing job name must start with an alphanumeric character."
+       invoke: Create
+       expect:
+         latest_state: "processing_job/v1alpha1/pj_invalid_create_attempted.yaml"
+         error: resource is in terminal condition

--- a/pkg/resource/training_job/manager_test_suite_test.go
+++ b/pkg/resource/training_job/manager_test_suite_test.go
@@ -11,15 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package feature_group
+package training_job
 
 import (
 	"errors"
 	"fmt"
 
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/ghodss/yaml"
-	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
@@ -51,14 +51,8 @@ func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMa
      }
 }
 
-// TestFeatureGroupTestSuite runs the test suite for feature group
-func TestFeatureGroupTestSuite(t *testing.T) {
-     	defer func() {
-     	   if r := recover(); r != nil {
-     	      fmt.Println(testutil.RecoverPanicString, r)
-	      t.Fail()
-     	   }
-        }()
+// TestTrainingJobTestSuite runs the test suite for training job
+func TestTrainingJobTestSuite(t *testing.T) {
 	var ts = testutil.TestSuite{}
 	testutil.LoadFromFixture(filepath.Join("testdata", "test_suite.yaml"), &ts)
 	var delegate = testRunnerDelegate{t: t}
@@ -89,14 +83,14 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	}
 	//TODO: use reflection, template to auto generate this block/method.
 	switch apiName {
-	case "CreateFeatureGroupWithContext":
-		var output svcsdk.CreateFeatureGroupOutput
+	case "CreateTrainingJobWithContext":
+		var output svcsdk.CreateTrainingJobOutput
 		return &output, nil
-	case "DeleteFeatureGroupWithContext":
-		var output svcsdk.DeleteFeatureGroupOutput
+	case "DescribeTrainingJobWithContext":
+		var output svcsdk.DescribeTrainingJobOutput
 		return &output, nil
-	case "DescribeFeatureGroupWithContext":
-		var output svcsdk.DescribeFeatureGroupOutput
+	case "StopTrainingJobWithContext":
+		var output svcsdk.StopTrainingJobOutput
 		return &output, nil
 	}
 	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))

--- a/pkg/resource/training_job/testdata/test_suite.yaml
+++ b/pkg/resource/training_job/testdata/test_suite.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: "Training job create tests"
+    description: "Part of training job CRD tests."
+    scenarios:
+     - name: "Create=InvalidInput"
+       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+       given:
+         desired_state: "training_job/v1alpha1/trainj_invalid_before_create.yaml"
+         svc_api:
+           - operation: CreateTrainingJobWithContext
+             error:
+               code: InvalidParameterValue
+               message: "The training job name must start with an alphanumeric character."
+       invoke: Create
+       expect:
+         latest_state: "training_job/v1alpha1/trainj_invalid_create_attempted.yaml"
+         error: resource is in terminal condition

--- a/pkg/resource/training_job/testdata/training_job/v1alpha1/trainj_invalid_before_create.yaml
+++ b/pkg/resource/training_job/testdata/training_job/v1alpha1/trainj_invalid_before_create.yaml
@@ -1,0 +1,51 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: TrainingJob
+metadata:
+  name: unit-testing-training-job
+spec:
+  trainingJobName: !-intentionally-invalid-name
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  hyperParameters:
+    max_depth: "5"
+    gamma: "4"
+    eta: "0.2"
+    min_child_weight: "6"
+    silent: "0"
+    objective: "multi:softmax"
+    num_class: "10"
+    num_round: "10"
+  algorithmSpecification:
+    trainingImage: 246618743249.dkr.ecr.us-west-2.amazonaws.com
+    trainingInputMode: File
+  outputDataConfig:
+    s3OutputPath: s3://source-data-bucket-592697580195-us-west-2/sagemaker/training/output
+  resourceConfig:
+    instanceCount: 1
+    instanceType: ml.m4.xlarge
+    volumeSizeInGB: 5
+  stoppingCondition:
+    maxRuntimeInSeconds: 86400
+  inputDataConfig:
+    - channelName: train
+      dataSource:
+        s3DataSource:
+          s3DataType: S3Prefix
+          s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/training/train
+          s3DataDistributionType: FullyReplicated
+      contentType: text/csv
+      compressionType: None
+    - channelName: validation
+      dataSource:
+        s3DataSource:
+          s3DataType: S3Prefix
+          s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/training/validation
+          s3DataDistributionType: FullyReplicated
+      contentType: text/csv
+      compressionType: None
+  tags:
+    - key: algorithm
+      value: xgboost
+    - key: environment
+      value: testing
+    - key: customer
+      value: test-user

--- a/pkg/resource/training_job/testdata/training_job/v1alpha1/trainj_invalid_create_attempted.yaml
+++ b/pkg/resource/training_job/testdata/training_job/v1alpha1/trainj_invalid_create_attempted.yaml
@@ -1,0 +1,59 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: TrainingJob
+metadata:
+  creationTimestamp: null
+  name: unit-testing-training-job
+spec:
+  algorithmSpecification:
+    trainingImage: 246618743249.dkr.ecr.us-west-2.amazonaws.com
+    trainingInputMode: File
+  hyperParameters:
+    eta: "0.2"
+    gamma: "4"
+    max_depth: "5"
+    min_child_weight: "6"
+    num_class: "10"
+    num_round: "10"
+    objective: multi:softmax
+    silent: "0"
+  inputDataConfig:
+  - channelName: train
+    compressionType: None
+    contentType: text/csv
+    dataSource:
+      s3DataSource:
+        s3DataDistributionType: FullyReplicated
+        s3DataType: S3Prefix
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/training/train
+  - channelName: validation
+    compressionType: None
+    contentType: text/csv
+    dataSource:
+      s3DataSource:
+        s3DataDistributionType: FullyReplicated
+        s3DataType: S3Prefix
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/training/validation
+  outputDataConfig:
+    s3OutputPath: s3://source-data-bucket-592697580195-us-west-2/sagemaker/training/output
+  resourceConfig:
+    instanceCount: 1
+    instanceType: ml.m4.xlarge
+    volumeSizeInGB: 5
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  stoppingCondition:
+    maxRuntimeInSeconds: 86400
+  tags:
+  - key: algorithm
+    value: xgboost
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user
+  trainingJobName: ""
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: The training job name must start with an alphanumeric character.
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/transform_job/custom_delta.go
+++ b/pkg/resource/transform_job/custom_delta.go
@@ -23,12 +23,16 @@ func customSetDefaults(
 	b *resource,
 ) {
 	// TransformInput is a required field.
-	if ackcompare.IsNil(a.ko.Spec.TransformInput.CompressionType) && ackcompare.IsNotNil(b.ko.Spec.TransformInput.CompressionType) {
-		a.ko.Spec.TransformInput.CompressionType = b.ko.Spec.TransformInput.CompressionType
+	if ackcompare.IsNotNil(a.ko.Spec.TransformInput) && ackcompare.IsNotNil(b.ko.Spec.TransformInput) {
+	   	if ackcompare.IsNil(a.ko.Spec.TransformInput.CompressionType) && ackcompare.IsNotNil(b.ko.Spec.TransformInput.CompressionType) {
+		   a.ko.Spec.TransformInput.CompressionType = b.ko.Spec.TransformInput.CompressionType
+		}
 	}
 
-	if ackcompare.IsNil(a.ko.Spec.TransformInput.SplitType) && ackcompare.IsNotNil(b.ko.Spec.TransformInput.SplitType) {
-		a.ko.Spec.TransformInput.SplitType = b.ko.Spec.TransformInput.SplitType
+	if ackcompare.IsNotNil(a.ko.Spec.TransformInput) && ackcompare.IsNotNil(b.ko.Spec.TransformInput) {
+	   	if ackcompare.IsNil(a.ko.Spec.TransformInput.SplitType) && ackcompare.IsNotNil(b.ko.Spec.TransformInput.SplitType) {
+		   a.ko.Spec.TransformInput.SplitType = b.ko.Spec.TransformInput.SplitType
+		}
 	}
 
 	// DataProcessing is not a required field, so first create it.

--- a/pkg/resource/transform_job/custom_delta.go
+++ b/pkg/resource/transform_job/custom_delta.go
@@ -16,13 +16,14 @@ package transform_job
 import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	svcapitypes "github.com/aws-controllers-k8s/sagemaker-controller/apis/v1alpha1"
+	"fmt"
 )
 
 func customSetDefaults(
 	a *resource,
 	b *resource,
 ) {
-
+	// TransformInput is a required field.
 	if ackcompare.IsNil(a.ko.Spec.TransformInput.CompressionType) && ackcompare.IsNotNil(b.ko.Spec.TransformInput.CompressionType) {
 		a.ko.Spec.TransformInput.CompressionType = b.ko.Spec.TransformInput.CompressionType
 	}

--- a/pkg/resource/transform_job/custom_delta.go
+++ b/pkg/resource/transform_job/custom_delta.go
@@ -16,7 +16,6 @@ package transform_job
 import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	svcapitypes "github.com/aws-controllers-k8s/sagemaker-controller/apis/v1alpha1"
-	"fmt"
 )
 
 func customSetDefaults(
@@ -28,10 +27,8 @@ func customSetDefaults(
 		a.ko.Spec.TransformInput.CompressionType = b.ko.Spec.TransformInput.CompressionType
 	}
 
-	if ackcompare.IsNotNil(a.ko.Spec.TransformInput) && ackcompare.IsNotNil(b.ko.Spec.TransformInput) {
-	   	if ackcompare.IsNil(a.ko.Spec.TransformInput.SplitType) && ackcompare.IsNotNil(b.ko.Spec.TransformInput.SplitType) {
-		   a.ko.Spec.TransformInput.SplitType = b.ko.Spec.TransformInput.SplitType
-		}
+	if ackcompare.IsNil(a.ko.Spec.TransformInput.SplitType) && ackcompare.IsNotNil(b.ko.Spec.TransformInput.SplitType) {
+		a.ko.Spec.TransformInput.SplitType = b.ko.Spec.TransformInput.SplitType
 	}
 
 	// DataProcessing is not a required field, so first create it.

--- a/pkg/resource/transform_job/custom_delta.go
+++ b/pkg/resource/transform_job/custom_delta.go
@@ -22,11 +22,9 @@ func customSetDefaults(
 	a *resource,
 	b *resource,
 ) {
-	// TransformInput is a required field.
-	if ackcompare.IsNotNil(a.ko.Spec.TransformInput) && ackcompare.IsNotNil(b.ko.Spec.TransformInput) {
-	   	if ackcompare.IsNil(a.ko.Spec.TransformInput.CompressionType) && ackcompare.IsNotNil(b.ko.Spec.TransformInput.CompressionType) {
-		   a.ko.Spec.TransformInput.CompressionType = b.ko.Spec.TransformInput.CompressionType
-		}
+
+	if ackcompare.IsNil(a.ko.Spec.TransformInput.CompressionType) && ackcompare.IsNotNil(b.ko.Spec.TransformInput.CompressionType) {
+		a.ko.Spec.TransformInput.CompressionType = b.ko.Spec.TransformInput.CompressionType
 	}
 
 	if ackcompare.IsNotNil(a.ko.Spec.TransformInput) && ackcompare.IsNotNil(b.ko.Spec.TransformInput) {

--- a/pkg/resource/transform_job/manager_test_suite_test.go
+++ b/pkg/resource/transform_job/manager_test_suite_test.go
@@ -11,15 +11,15 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package feature_group
+package transform_job
 
 import (
 	"errors"
 	"fmt"
 
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/ghodss/yaml"
-	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
@@ -51,14 +51,8 @@ func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMa
      }
 }
 
-// TestFeatureGroupTestSuite runs the test suite for feature group
-func TestFeatureGroupTestSuite(t *testing.T) {
-     	defer func() {
-     	   if r := recover(); r != nil {
-     	      fmt.Println(testutil.RecoverPanicString, r)
-	      t.Fail()
-     	   }
-        }()
+// TestTransformJobTestSuite runs the test suite for transform job
+func TestTransformJobTestSuite(t *testing.T) {
 	var ts = testutil.TestSuite{}
 	testutil.LoadFromFixture(filepath.Join("testdata", "test_suite.yaml"), &ts)
 	var delegate = testRunnerDelegate{t: t}
@@ -89,14 +83,14 @@ func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{},
 	}
 	//TODO: use reflection, template to auto generate this block/method.
 	switch apiName {
-	case "CreateFeatureGroupWithContext":
-		var output svcsdk.CreateFeatureGroupOutput
+	case "CreateTransformJobWithContext":
+		var output svcsdk.CreateTransformJobOutput
 		return &output, nil
-	case "DeleteFeatureGroupWithContext":
-		var output svcsdk.DeleteFeatureGroupOutput
+	case "DescribeTransformJobWithContext":
+		var output svcsdk.DescribeTransformJobOutput
 		return &output, nil
-	case "DescribeFeatureGroupWithContext":
-		var output svcsdk.DescribeFeatureGroupOutput
+	case "StopTransformJobWithContext":
+		var output svcsdk.StopTransformJobOutput
 		return &output, nil
 	}
 	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))

--- a/pkg/resource/transform_job/testdata/test_suite.yaml
+++ b/pkg/resource/transform_job/testdata/test_suite.yaml
@@ -1,0 +1,17 @@
+tests:
+  - name: "Transform job create tests"
+    description: "Part of transform job CRD tests."
+    scenarios:
+     - name: "Create=InvalidInput"
+       description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+       given:
+         desired_state: "transform_job/v1alpha1/transformj_invalid_before_create.yaml"
+         svc_api:
+           - operation: CreateTransformJobWithContext
+             error:
+               code: InvalidParameterValue
+               message: "The transform job name must start with an alphanumeric character."
+       invoke: Create
+       expect:
+         latest_state: "transform_job/v1alpha1/transformj_invalid_create_attempted.yaml"
+         error: resource is in terminal condition

--- a/pkg/resource/transform_job/testdata/transform_job/v1alpha1/transformj_invalid_before_create.yaml
+++ b/pkg/resource/transform_job/testdata/transform_job/v1alpha1/transformj_invalid_before_create.yaml
@@ -1,0 +1,25 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: TransformJob
+metadata:
+  name: unit-testing-transform-job
+spec:
+  transformJobName: !-intentionally-invalid-name
+  modelName: xgboost-churn-config-model
+  transformInput:
+    contentType: text/csv
+    dataSource:
+      s3DataSource:
+        s3DataType: S3Prefix
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/batch/input-data
+  transformOutput:
+    s3OutputPath: s3://source-data-bucket-592697580195-us-west-2/sagemaker/batch/output
+  transformResources:
+    instanceCount: 1
+    instanceType: ml.m5.large
+  tags:
+    - key: algorithm
+      value: xgboost
+    - key: environment
+      value: testing
+    - key: customer
+      value: test-user

--- a/pkg/resource/transform_job/testdata/transform_job/v1alpha1/transformj_invalid_create_attempted.yaml
+++ b/pkg/resource/transform_job/testdata/transform_job/v1alpha1/transformj_invalid_create_attempted.yaml
@@ -1,0 +1,33 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: TransformJob
+metadata:
+  creationTimestamp: null
+  name: unit-testing-transform-job
+spec:
+  modelName: xgboost-churn-config-model
+  tags:
+  - key: algorithm
+    value: xgboost
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user
+  transformInput:
+    contentType: text/csv
+    dataSource:
+      s3DataSource:
+        s3DataType: S3Prefix
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/batch/input-data
+  transformJobName: ""
+  transformOutput:
+    s3OutputPath: s3://source-data-bucket-592697580195-us-west-2/sagemaker/batch/output
+  transformResources:
+    instanceCount: 1
+    instanceType: ml.m5.large
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: The transform job name must start with an alphanumeric character.
+    status: "True"
+    type: ACK.Terminal


### PR DESCRIPTION
Note that this PR is meant to be merged on top of PRs [#66](https://github.com/aws-controllers-k8s/sagemaker-controller/pull/66) and [#68](https://github.com/aws-controllers-k8s/sagemaker-controller/pull/68)

Summary: Added example Create with invalid input unit test for all resources.

Code Coverage: 26.0%

New Files Per Resource [resource-name]:
(4 files/feature * 14 features = 56 new files)

- pkg/resource/**[resource-name]**/manager_test_suite_test.go
   - Contains resource specific helper functions for unit testing 
- pkg/resource/**[resource-name]**/testdata/test_suite.yaml
   - Contains the written out unit test
- pkg/resource/**[resource-name]**/testdata/endpoint/v1alpha1/**[resource-abbreviation]**_cmd_invalid_before_create.yaml
   - Example input / desired state file that is used for testing Create functionality with an InvalidParameterValue.
- pkg/resource/**[resource-name]**/testdata/endpoint/v1alpha1/**[resource-abbreviation]**_cmd_invalid_create_attempted.yaml
   - Example output / expected state file that is used for testing Create functionality with an InvalidParameterValue.