### PR TITLE
Training profiler support

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,14 +1,14 @@
 ack_generate_info:
-  build_date: "2021-08-12T00:32:37Z"
+  build_date: "2021-08-12T23:35:21Z"
   build_hash: c77aa9c75d944952dee198029ba9822691cd82b0
   go_version: go1.16.4 linux/amd64
   version: v0.6.0
-api_directory_checksum: c8f263a8d1a2e21f53c85b1ca5e2be3687045dd0
+api_directory_checksum: f7275158658c496010e6e3d2d24b3aba37e2e1f4
 api_version: v1alpha1
 aws_sdk_go_version: v1.38.11
 generator_config_info:
-  file_checksum: 795f6cf17e64a254ed063ee36e489b2949a031ef
+  file_checksum: 4acc645991dfd96fd543c3c34df274a8e4f4787e
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-08-12 00:32:40.304705695 +0000 UTC
+  timestamp: 2021-08-12 23:35:25.778426245 +0000 UTC

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -1,6 +1,4 @@
 operations:
-  DescribeTrainingJob:
-    set_output_custom_method_name: customDescribeTrainingJobSetOutput
   StopTrainingJob:
     operation_type: Delete
     resource_name: TrainingJob
@@ -169,7 +167,9 @@ resources:
       delta_pre_compare:
         code: customSetDefaults(a, b)
       sdk_create_post_set_output:
-        code: rm.customSetOutput(desired, aws.String(svcsdk.TrainingJobStatusInProgress), ko)
+        code: rm.customCreateTrainingJobSetOutput(&resource{ko})
+      sdk_read_one_post_set_output:
+        code: rm.customDescribeTrainingJobSetOutput(&resource{ko})
       sdk_delete_pre_build_request:
         template_path: training_job/sdk_delete_pre_build_request.go.tpl
     fields:
@@ -191,7 +191,17 @@ resources:
         is_read_only: true
         from:
           operation: DescribeTrainingJob
-          path: DebugRuleEvaluationStatuses 
+          path: DebugRuleEvaluationStatuses
+      ProfilerRuleEvaluationStatuses:
+        is_read_only: true
+        from:
+          operation: DescribeTrainingJob
+          path: ProfilerRuleEvaluationStatuses
+      ModelArtifacts:
+        is_read_only: true
+        from:
+          operation: DescribeTrainingJob
+          path: ModelArtifacts
       FailureReason:
         is_read_only: true
         print:

--- a/apis/v1alpha1/training_job.go
+++ b/apis/v1alpha1/training_job.go
@@ -167,6 +167,11 @@ type TrainingJobStatus struct {
 	DebugRuleEvaluationStatuses []*DebugRuleEvaluationStatus `json:"debugRuleEvaluationStatuses,omitempty"`
 	// If the training job failed, the reason it failed.
 	FailureReason *string `json:"failureReason,omitempty"`
+	// Information about the Amazon S3 location that is configured for storing model
+	// artifacts.
+	ModelArtifacts *ModelArtifacts `json:"modelArtifacts,omitempty"`
+	// Evaluation status of Debugger rules for profiling on a training job.
+	ProfilerRuleEvaluationStatuses []*ProfilerRuleEvaluationStatus `json:"profilerRuleEvaluationStatuses,omitempty"`
 	// Provides detailed information about the state of the training job. For detailed
 	// information on the secondary status of the training job, see StatusMessage
 	// under SecondaryStatusTransition.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -9732,6 +9732,22 @@ func (in *TrainingJobStatus) DeepCopyInto(out *TrainingJobStatus) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ModelArtifacts != nil {
+		in, out := &in.ModelArtifacts, &out.ModelArtifacts
+		*out = new(ModelArtifacts)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.ProfilerRuleEvaluationStatuses != nil {
+		in, out := &in.ProfilerRuleEvaluationStatuses, &out.ProfilerRuleEvaluationStatuses
+		*out = make([]*ProfilerRuleEvaluationStatus, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(ProfilerRuleEvaluationStatus)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.SecondaryStatus != nil {
 		in, out := &in.SecondaryStatus, &out.SecondaryStatus
 		*out = new(string)

--- a/config/crd/bases/sagemaker.services.k8s.aws_trainingjobs.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_trainingjobs.yaml
@@ -516,6 +516,32 @@ spec:
               failureReason:
                 description: If the training job failed, the reason it failed.
                 type: string
+              modelArtifacts:
+                description: Information about the Amazon S3 location that is configured
+                  for storing model artifacts.
+                properties:
+                  s3ModelArtifacts:
+                    type: string
+                type: object
+              profilerRuleEvaluationStatuses:
+                description: Evaluation status of Debugger rules for profiling on
+                  a training job.
+                items:
+                  description: Information about the status of the rule evaluation.
+                  properties:
+                    lastModifiedTime:
+                      format: date-time
+                      type: string
+                    ruleConfigurationName:
+                      type: string
+                    ruleEvaluationJobARN:
+                      type: string
+                    ruleEvaluationStatus:
+                      type: string
+                    statusDetails:
+                      type: string
+                  type: object
+                type: array
               secondaryStatus:
                 description: "Provides detailed information about the state of the
                   training job. For detailed information on the secondary status of

--- a/generator.yaml
+++ b/generator.yaml
@@ -1,6 +1,4 @@
 operations:
-  DescribeTrainingJob:
-    set_output_custom_method_name: customDescribeTrainingJobSetOutput
   StopTrainingJob:
     operation_type: Delete
     resource_name: TrainingJob
@@ -169,7 +167,9 @@ resources:
       delta_pre_compare:
         code: customSetDefaults(a, b)
       sdk_create_post_set_output:
-        code: rm.customSetOutput(desired, aws.String(svcsdk.TrainingJobStatusInProgress), ko)
+        code: rm.customCreateTrainingJobSetOutput(&resource{ko})
+      sdk_read_one_post_set_output:
+        code: rm.customDescribeTrainingJobSetOutput(&resource{ko})
       sdk_delete_pre_build_request:
         template_path: training_job/sdk_delete_pre_build_request.go.tpl
     fields:
@@ -191,7 +191,17 @@ resources:
         is_read_only: true
         from:
           operation: DescribeTrainingJob
-          path: DebugRuleEvaluationStatuses 
+          path: DebugRuleEvaluationStatuses
+      ProfilerRuleEvaluationStatuses:
+        is_read_only: true
+        from:
+          operation: DescribeTrainingJob
+          path: ProfilerRuleEvaluationStatuses
+      ModelArtifacts:
+        is_read_only: true
+        from:
+          operation: DescribeTrainingJob
+          path: ModelArtifacts
       FailureReason:
         is_read_only: true
         print:

--- a/pkg/resource/training_job/sdk.go
+++ b/pkg/resource/training_job/sdk.go
@@ -354,6 +354,15 @@ func (rm *resourceManager) sdkFind(
 	} else {
 		ko.Spec.InputDataConfig = nil
 	}
+	if resp.ModelArtifacts != nil {
+		f19 := &svcapitypes.ModelArtifacts{}
+		if resp.ModelArtifacts.S3ModelArtifacts != nil {
+			f19.S3ModelArtifacts = resp.ModelArtifacts.S3ModelArtifacts
+		}
+		ko.Status.ModelArtifacts = f19
+	} else {
+		ko.Status.ModelArtifacts = nil
+	}
 	if resp.OutputDataConfig != nil {
 		f20 := &svcapitypes.OutputDataConfig{}
 		if resp.OutputDataConfig.KmsKeyId != nil {
@@ -423,6 +432,31 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.ProfilerRuleConfigurations = f22
 	} else {
 		ko.Spec.ProfilerRuleConfigurations = nil
+	}
+	if resp.ProfilerRuleEvaluationStatuses != nil {
+		f23 := []*svcapitypes.ProfilerRuleEvaluationStatus{}
+		for _, f23iter := range resp.ProfilerRuleEvaluationStatuses {
+			f23elem := &svcapitypes.ProfilerRuleEvaluationStatus{}
+			if f23iter.LastModifiedTime != nil {
+				f23elem.LastModifiedTime = &metav1.Time{*f23iter.LastModifiedTime}
+			}
+			if f23iter.RuleConfigurationName != nil {
+				f23elem.RuleConfigurationName = f23iter.RuleConfigurationName
+			}
+			if f23iter.RuleEvaluationJobArn != nil {
+				f23elem.RuleEvaluationJobARN = f23iter.RuleEvaluationJobArn
+			}
+			if f23iter.RuleEvaluationStatus != nil {
+				f23elem.RuleEvaluationStatus = f23iter.RuleEvaluationStatus
+			}
+			if f23iter.StatusDetails != nil {
+				f23elem.StatusDetails = f23iter.StatusDetails
+			}
+			f23 = append(f23, f23elem)
+		}
+		ko.Status.ProfilerRuleEvaluationStatuses = f23
+	} else {
+		ko.Status.ProfilerRuleEvaluationStatuses = nil
 	}
 	if resp.ResourceConfig != nil {
 		f25 := &svcapitypes.ResourceConfig{}
@@ -519,11 +553,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
-	// custom set output from response
-	ko, err = rm.customDescribeTrainingJobSetOutput(ctx, r, resp, ko)
-	if err != nil {
-		return nil, err
-	}
+	rm.customDescribeTrainingJobSetOutput(&resource{ko})
 	return &resource{ko}, nil
 }
 
@@ -586,7 +616,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-	rm.customSetOutput(desired, aws.String(svcsdk.TrainingJobStatusInProgress), ko)
+	rm.customCreateTrainingJobSetOutput(&resource{ko})
 	return &resource{ko}, nil
 }
 

--- a/test/e2e/common/config.py
+++ b/test/e2e/common/config.py
@@ -23,7 +23,7 @@ MODEL_PACKAGE_GROUP_RESOURCE_PLURAL = "modelpackagegroups"
 LIST_JOB_STATUS_STOPPED = ("Stopped", "Stopping", "Completed")
 JOB_STATUS_INPROGRESS: str = "InProgress"
 JOB_STATUS_COMPLETED: str = "Completed"
-DEBUGGERJOB_STATUS_COMPLETED: str = "NoIssuesFound"
+RULE_STATUS_COMPLETED: str = "NoIssuesFound"
 
 ENDPOINT_STATUS_INSERVICE = "InService"
 ENDPOINT_STATUS_CREATING = "Creating"

--- a/test/e2e/resources/xgboost_trainingjob_debugger.yaml
+++ b/test/e2e/resources/xgboost_trainingjob_debugger.yaml
@@ -68,6 +68,14 @@ spec:
         collection_names: metrics
         num_steps: "10"
         rule_to_invoke: LossNotDecreasing
+  profilerConfig:
+    s3OutputPath: s3://$SAGEMAKER_DATA_BUCKET/sagemaker/training/profiler/
+    profilingIntervalInMilliseconds: 500
+  profilerRuleConfigurations:
+    - ruleConfigurationName: ProfilerReport
+      ruleEvaluatorImage: $DEBUGGER_IMAGE_URI
+      ruleParameters:
+        rule_to_invoke: ProfilerReport
   tags:
     - key: algorithm
       value: xgboost

--- a/test/e2e/tests/test_trainingjob.py
+++ b/test/e2e/tests/test_trainingjob.py
@@ -13,18 +13,16 @@
 """Integration tests for the SageMaker TrainingJob API.
 """
 
-import botocore
 import pytest
 import logging
-from typing import Dict
 
 from acktest.resources import random_suffix_name
 from acktest.k8s import resource as k8s
 from e2e import (
     service_marker,
-    wait_for_status,
     create_sagemaker_resource,
-    sagemaker_client,
+    get_sagemaker_training_job,
+    assert_training_status_in_sync,
     assert_tags_in_sync,
 )
 from e2e.replacement_values import REPLACEMENT_VALUES
@@ -59,73 +57,9 @@ def xgboost_training_job():
         _, deleted = k8s.delete_custom_resource(reference, 3, 10)
         assert deleted
 
-
-def get_sagemaker_training_job(training_job_name: str):
-    try:
-        training_job = sagemaker_client().describe_training_job(
-            TrainingJobName=training_job_name
-        )
-        return training_job
-    except botocore.exceptions.ClientError as error:
-        logging.error(
-            f"SageMaker could not find a training job with the name {training_job_name}. Error {error}"
-        )
-        return None
-
-
-def get_training_sagemaker_status(training_job_name: str):
-    training_sm_desc = get_sagemaker_training_job(training_job_name)
-    return training_sm_desc["TrainingJobStatus"]
-
-
-def get_training_resource_status(reference: k8s.CustomResourceReference):
-    resource = k8s.get_resource(reference)
-    assert "trainingJobStatus" in resource["status"]
-    return resource["status"]["trainingJobStatus"]
-
-
 @pytest.mark.canary
 @service_marker
 class TestTrainingJob:
-    def _wait_resource_training_status(
-        self,
-        reference: k8s.CustomResourceReference,
-        expected_status: str,
-        wait_periods: int = 30,
-        period_length: int = 30,
-    ):
-        return wait_for_status(
-            expected_status,
-            wait_periods,
-            period_length,
-            get_training_resource_status,
-            reference,
-        )
-
-    def _wait_sagemaker_training_status(
-        self,
-        training_job_name,
-        expected_status: str,
-        wait_periods: int = 30,
-        period_length: int = 30,
-    ):
-        return wait_for_status(
-            expected_status,
-            wait_periods,
-            period_length,
-            get_training_sagemaker_status,
-            training_job_name,
-        )
-
-    def _assert_training_status_in_sync(
-        self, training_job_name, reference, expected_status
-    ):
-        assert (
-            self._wait_sagemaker_training_status(training_job_name, expected_status)
-            == self._wait_resource_training_status(reference, expected_status)
-            == expected_status
-        )
-
     def test_stopped(self, xgboost_training_job):
         (reference, resource) = xgboost_training_job
         assert k8s.get_resource_exists(reference)
@@ -139,7 +73,7 @@ class TestTrainingJob:
         assert training_job_desc["TrainingJobStatus"] == cfg.JOB_STATUS_INPROGRESS
         assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "False")
 
-        self._assert_training_status_in_sync(
+        assert_training_status_in_sync(
             training_job_name, reference, cfg.JOB_STATUS_INPROGRESS
         )
 
@@ -164,10 +98,14 @@ class TestTrainingJob:
         assert training_job_desc["TrainingJobStatus"] == cfg.JOB_STATUS_INPROGRESS
         assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "False")
 
-        self._assert_training_status_in_sync(
+        assert_training_status_in_sync(
             training_job_name, reference, cfg.JOB_STATUS_COMPLETED
         )
         assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True")
+
+        # model artifact URL is populated
+        resource = k8s.get_resource(reference)
+        resource["status"]["modelArtifacts"]["s3ModelArtifacts"] is not None
 
         resource_tags = resource["spec"].get("tags", None)
         assert_tags_in_sync(training_job_arn, resource_tags)

--- a/test/e2e/tests/test_trainingjob_debugger.py
+++ b/test/e2e/tests/test_trainingjob_debugger.py
@@ -13,10 +13,8 @@
 """Integration tests for the SageMaker TrainingJob API.
 """
 
-import botocore
 import pytest
 import logging
-from typing import Dict
 
 from acktest.resources import random_suffix_name
 from acktest.k8s import resource as k8s
@@ -24,11 +22,11 @@ from e2e import (
     service_marker,
     create_sagemaker_resource,
     wait_for_status,
-    sagemaker_client,
+    get_sagemaker_training_job,
+    assert_training_status_in_sync,
     assert_tags_in_sync,
 )
 from e2e.replacement_values import REPLACEMENT_VALUES
-from e2e.bootstrap_resources import get_bootstrap_resources
 from e2e.common import config as cfg
 
 RESOURCE_PLURAL = "trainingjobs"
@@ -36,7 +34,7 @@ RESOURCE_PLURAL = "trainingjobs"
 
 @pytest.fixture(scope="function")
 def xgboost_training_job_debugger():
-    resource_name = random_suffix_name("xgboost-trainingjob-debugger", 32)
+    resource_name = random_suffix_name("xgboost-trainingjob-debugger", 50)
     replacements = REPLACEMENT_VALUES.copy()
     replacements["TRAINING_JOB_NAME"] = resource_name
     reference, _, resource = create_sagemaker_resource(
@@ -45,12 +43,7 @@ def xgboost_training_job_debugger():
         spec_file="xgboost_trainingjob_debugger",
         replacements=replacements,
     )
-    if k8s.get_resource_arn(resource) is None:
-        logging.error(
-            f"ARN for this resource is None, resource status is: {resource['status']}"
-        )
     assert resource is not None
-    assert k8s.get_resource_arn(resource) is not None
 
     yield (reference, resource)
 
@@ -59,50 +52,25 @@ def xgboost_training_job_debugger():
         assert deleted
 
 
-def get_sagemaker_training_job(training_job_name: str):
-    try:
-        training_job = sagemaker_client().describe_training_job(
-            TrainingJobName=training_job_name
-        )
-        return training_job
-    except botocore.exceptions.ClientError as error:
-        logging.error(
-            f"SageMaker could not find a training debugger job with the name {training_job_name}. Error {error}"
-        )
-        return None
-
-
-# TODO: Move to __init__.py
-def get_training_sagemaker_status(training_job_name: str):
+def get_training_rule_eval_sagemaker_status(training_job_name: str, rule_type: str):
     training_sm_desc = get_sagemaker_training_job(training_job_name)
-    return training_sm_desc["TrainingJobStatus"]
+    return training_sm_desc[rule_type+"EvaluationStatuses"][0]["RuleEvaluationStatus"]
 
 
-def get_training_resource_status(reference: k8s.CustomResourceReference):
+def get_training_rule_eval_resource_status(reference: k8s.CustomResourceReference, rule_type: str):
     resource = k8s.get_resource(reference)
-    assert "trainingJobStatus" in resource["status"]
-    return resource["status"]["trainingJobStatus"]
-
-
-def get_training_debugger_sagemaker_status(training_job_name: str):
-    training_sm_desc = get_sagemaker_training_job(training_job_name)
-    return training_sm_desc["DebugRuleEvaluationStatuses"][0]["RuleEvaluationStatus"]
-
-
-def get_training_debugger_resource_status(reference: k8s.CustomResourceReference):
-    resource = k8s.get_resource(reference)
-    resource_status = resource["status"]["debugRuleEvaluationStatuses"][0][
+    resource_status = resource["status"][rule_type+"EvaluationStatuses"][0][
         "ruleEvaluationStatus"
     ]
     assert resource_status is not None
     return resource_status
 
-
 @service_marker
 class TestTrainingDebuggerJob:
-    def _wait_sagemaker_training_status(
+    def _wait_sagemaker_training_rule_eval_status(
         self,
         training_job_name,
+        rule_type: str,
         expected_status: str,
         wait_periods: int = 30,
         period_length: int = 30,
@@ -111,13 +79,15 @@ class TestTrainingDebuggerJob:
             expected_status,
             wait_periods,
             period_length,
-            get_training_sagemaker_status,
+            get_training_rule_eval_sagemaker_status,
             training_job_name,
+            rule_type,
         )
 
-    def _wait_resource_training_status(
+    def _wait_resource_training_rule_eval_status(
         self,
         reference: k8s.CustomResourceReference,
+        rule_type: str,
         expected_status: str,
         wait_periods: int = 30,
         period_length: int = 30,
@@ -126,57 +96,20 @@ class TestTrainingDebuggerJob:
             expected_status,
             wait_periods,
             period_length,
-            get_training_resource_status,
+            get_training_rule_eval_resource_status,
             reference,
+            rule_type,
         )
 
-    def _assert_training_status_in_sync(
-        self, training_job_name, reference, expected_status
+    def _assert_training_rule_eval_status_in_sync(
+        self, training_job_name, sagemaker_rule_type, reference, expected_status
     ):
+        resource_rule_type = sagemaker_rule_type[0].lower() + sagemaker_rule_type[1:]
         assert (
-            self._wait_sagemaker_training_status(training_job_name, expected_status)
-            == self._wait_resource_training_status(reference, expected_status)
-            == expected_status
-        )
-
-    def _wait_sagemaker_training_debugger_status(
-        self,
-        training_job_name,
-        expected_status: str,
-        wait_periods: int = 30,
-        period_length: int = 30,
-    ):
-        return wait_for_status(
-            expected_status,
-            wait_periods,
-            period_length,
-            get_training_debugger_sagemaker_status,
-            training_job_name,
-        )
-
-    def _wait_resource_training_debugger_status(
-        self,
-        reference: k8s.CustomResourceReference,
-        expected_status: str,
-        wait_periods: int = 30,
-        period_length: int = 30,
-    ):
-        return wait_for_status(
-            expected_status,
-            wait_periods,
-            period_length,
-            get_training_debugger_resource_status,
-            reference,
-        )
-
-    def _assert_training_debugger_status_in_sync(
-        self, training_job_name, reference, expected_status
-    ):
-        assert (
-            self._wait_sagemaker_training_debugger_status(
-                training_job_name, expected_status
+            self._wait_sagemaker_training_rule_eval_status(
+                training_job_name, sagemaker_rule_type, expected_status, 
             )
-            == self._wait_resource_training_debugger_status(reference, expected_status)
+            == self._wait_resource_training_rule_eval_status(reference, resource_rule_type, expected_status)
             == expected_status
         )
 
@@ -189,19 +122,30 @@ class TestTrainingDebuggerJob:
 
         training_job_desc = get_sagemaker_training_job(training_job_name)
         training_job_arn = training_job_desc["TrainingJobArn"]
-        assert k8s.get_resource_arn(resource) == training_job_arn
+        
+        resource_arn = k8s.get_resource_arn(resource)
+        if resource_arn is None:
+            logging.error(
+                f"ARN for this resource is None, resource status is: {resource['status']}"
+            )
+        assert resource_arn == training_job_arn
 
         assert training_job_desc["TrainingJobStatus"] == cfg.JOB_STATUS_INPROGRESS
         assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "False")
 
-        self._assert_training_status_in_sync(
+        assert_training_status_in_sync(
             training_job_name, reference, cfg.JOB_STATUS_COMPLETED
         )
-        # TODO: This test is failing
         assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "False")
 
-        self._assert_training_debugger_status_in_sync(
-            training_job_name, reference, cfg.DEBUGGERJOB_STATUS_COMPLETED
+        # Assert debugger rule evaluation completed
+        self._assert_training_rule_eval_status_in_sync(
+            training_job_name, "DebugRule", reference, cfg.RULE_STATUS_COMPLETED
+        )
+        
+        # Assert profiler rule evaluation completed
+        self._assert_training_rule_eval_status_in_sync(
+            training_job_name, "ProfilerRule", reference, cfg.RULE_STATUS_COMPLETED
         )
         assert k8s.wait_on_condition(reference, "ACK.ResourceSynced", "True")
 


### PR DESCRIPTION
- Requeue for profiler jobs in training
- Refactor to reduce code duplication and use common pkg
- Includes some test refactoring to include both profiler and debugger
- Clean up code duplication in test_training and test_training_debugger

**TODO**
fix docs in crd fields getting changed

### Testing

```
(ack) ubuntu@ip-172-31-0-119:~/go/src/github.com/aws-controllers-k8s/sagemaker-controller/test/e2e$ pytest tests/test_trainingjob.py 
========================================== test session starts ==========================================
platform linux -- Python 3.8.8, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/ubuntu/go/src/github.com/aws-controllers-k8s/sagemaker-controller/test/e2e
plugins: xdist-2.2.0, forked-1.3.0
collected 2 items                                                                                       

tests/test_trainingjob.py ..                                                                      [100%]

===================================== 2 passed in 441.19s (0:07:21) =====================================
```

```
(ack) ubuntu@ip-172-31-0-119:~/go/src/github.com/aws-controllers-k8s/sagemaker-controller/test/e2e$ pytest tests/test_trainingjob_debugger.py 
========================================== test session starts ==========================================
platform linux -- Python 3.8.8, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/ubuntu/go/src/github.com/aws-controllers-k8s/sagemaker-controller/test/e2e
plugins: xdist-2.2.0, forked-1.3.0
collected 1 item                                                                                        

tests/test_trainingjob_debugger.py .                                                              [100%]

===================================== 1 passed in 629.97s (0:10:29) =====================================
```