### PR TITLE
Remove dockerhub login step and use ECR public gallery ubuntu image

### DIFF
--- a/test/canary/Dockerfile.canary
+++ b/test/canary/Dockerfile.canary
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04
 
 # Build time parameters 
 ARG SERVICE=sagemaker

--- a/test/canary/canary.buildspec.yaml
+++ b/test/canary/canary.buildspec.yaml
@@ -10,9 +10,6 @@ phases:
       - aws ecr get-login-password --region $CLUSTER_REGION | docker login --username AWS --password-stdin $ECR_CACHE_URI || true
       - docker pull ${ECR_CACHE_URI}:latest --quiet || true
 
-      # Login to dockerhub to avoid hitting throttle limit
-      - docker login -u $DOCKER_CONFIG_USERNAME -p $DOCKER_CONFIG_PASSWORD
-
       # Build test image
       - >
         docker build -f ./test/canary/Dockerfile.canary . -t ${ECR_CACHE_URI}:latest


### PR DESCRIPTION
This is required so that we do not need to support dockerhub and its credentials. 
1. Remove dockerhub login step from the codebuild spec file.  
2. Use [ECR public gallery ubuntu image](https://gallery.ecr.aws/ubuntu/ubuntu) in the Canary Docker Image instead

### Testing
For testing I added this commit on top of the `canary` branch and pushed to a new upstream branch [`docker-on-ecr-on-canary-branch`](https://github.com/aws-controllers-k8s/sagemaker-controller/tree/docker-on-ecr-on-canary-branch). Then ran the canary test job on this branch. 