### PR TITLE
Use tmp file in unit-tests to allow for testing portability

### DIFF
--- a/pkg/testutil/util.go
+++ b/pkg/testutil/util.go
@@ -88,10 +88,7 @@ func IsYamlEqual(expectation *string, actualYamlByteArray *[]byte) bool {
 	// Remove tmp files used as backup https://riptutorial.com/sed/topic/9436/bsd-macos-sed-vs--gnu-sed-vs--the-posix-sed-specification
 	// -i inplace-editing is not consistent on both GNU and non-GNU sed when not specifiying a backup file.
 	actualYamlFileNameTmp := actualYamlFileName + ".tmp"
-	_, err = exec.Command("rm", actualYamlFileNameTmp).Output()
-	if isExecCommandError(err) {
-		return false
-	}
+	defer os.Remove(actualYamlFileNameTmp)
 
 	output, err := exec.Command("diff", "-c", expectedYamlFileName, actualYamlFileName).Output()
 	if isExecCommandError(err) {

--- a/pkg/testutil/util.go
+++ b/pkg/testutil/util.go
@@ -17,13 +17,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/ghodss/yaml"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
 	"strings"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/ghodss/yaml"
 )
 
 var (
@@ -79,7 +80,15 @@ func IsYamlEqual(expectation *string, actualYamlByteArray *[]byte) bool {
 	}
 
 	// Replace Timestamps that would show up as different.
-	_, err := exec.Command("sed", "-r", "-i", ReplaceTimestampRegExp, actualYamlFileName).Output()
+	_, err := exec.Command("sed", "-r", "-i.tmp", ReplaceTimestampRegExp, actualYamlFileName).Output()
+	if isExecCommandError(err) {
+		return false
+	}
+
+	// Remove tmp files used as backup https://riptutorial.com/sed/topic/9436/bsd-macos-sed-vs--gnu-sed-vs--the-posix-sed-specification
+	// -i inplace-editing is not consistent on both GNU and non-GNU sed when not specifiying a backup file.
+	actualYamlFileNameTmp := actualYamlFileName + ".tmp"
+	_, err = exec.Command("rm", actualYamlFileNameTmp).Output()
 	if isExecCommandError(err) {
 		return false
 	}


### PR DESCRIPTION
Description of changes:
Unit tests fail when not using GNU sed this is because command uses `sed -i` which when not using GNU sed needs to specify a string afterwards which can be defaulted to `sed -i ''` However when attempting this allows for the unit-tests to pass but it created tmp files on my end with suffix ''. Ended up creating .tmp files initially and then removing them, this is consistent with the GNU internal implementation. https://www.gnu.org/software/sed/manual/sed.html#index-_002di 

> GNU sed does this by creating a temporary file and sending output to this file rather than to the standard output

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
