### PR TITLE
remove status.EndpointConfig* from endpoint CRD

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,14 +1,14 @@
 ack_generate_info:
-  build_date: "2021-09-01T00:07:38Z"
-  build_hash: 6f22b7b568e25b4ee007bb1ab5f9338c16daf172
+  build_date: "2021-09-01T01:05:16Z"
+  build_hash: 07d7ea755625b2cac93bbf293bf5a8cab24ecb68
   go_version: go1.16.4 linux/amd64
   version: v0.13.0
-api_directory_checksum: 13c67d2ac904c5b3c1ddea34aba38d90f06f3adc
+api_directory_checksum: a0f6457435f0a16addd9cf7d0acef2830722bd78
 api_version: v1alpha1
 aws_sdk_go_version: v1.38.11
 generator_config_info:
-  file_checksum: 95bf43b6a68c009a14db1ba7bd91293ca03aee15
+  file_checksum: 5431bfc09117e092ee89a98edcbad6934363dea2
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-09-01 00:07:46.08290738 +0000 UTC
+  timestamp: 2021-09-01 01:05:19.682637714 +0000 UTC

--- a/apis/v1alpha1/endpoint.go
+++ b/apis/v1alpha1/endpoint.go
@@ -87,15 +87,9 @@ type EndpointStatus struct {
 	// If the status of the endpoint is Failed, the reason why it failed.
 	// +kubebuilder:validation:Optional
 	FailureReason *string `json:"failureReason,omitempty"`
-	// Name of the Amazon SageMaker endpoint configuration.
-	// +kubebuilder:validation:Optional
-	LastEndpointConfigNameForUpdate *string `json:"lastEndpointConfigNameForUpdate,omitempty"`
 	// A timestamp that shows when the endpoint was last modified.
 	// +kubebuilder:validation:Optional
 	LastModifiedTime *metav1.Time `json:"lastModifiedTime,omitempty"`
-	// The name of the endpoint configuration associated with this endpoint.
-	// +kubebuilder:validation:Optional
-	LatestEndpointConfigName *string `json:"latestEndpointConfigName,omitempty"`
 	// An array of ProductionVariantSummary objects, one for each model hosted behind
 	// this endpoint.
 	// +kubebuilder:validation:Optional

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -73,7 +73,7 @@ resources:
         - EndpointUpdateError
     hooks:
       sdk_read_one_post_set_output:
-        code: rm.customDescribeEndpointSetOutput(resp, ko)
+        code: rm.customDescribeEndpointSetOutput(ko)
       sdk_update_pre_build_request:
         template_path: endpoint/sdk_update_pre_build_request.go.tpl
       sdk_update_post_set_output:
@@ -96,16 +96,6 @@ resources:
         from:
           operation: DescribeEndpoint
           path: FailureReason
-      LatestEndpointConfigName:
-        is_read_only: true
-        from:
-          operation: DescribeEndpoint
-          path: EndpointConfigName
-      LastEndpointConfigNameForUpdate:
-        is_read_only: true
-        from:
-          operation: DescribeEndpointConfig
-          path: EndpointConfigName
       CreationTime:
         is_read_only: true
         from:

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -2507,19 +2507,9 @@ func (in *EndpointStatus) DeepCopyInto(out *EndpointStatus) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.LastEndpointConfigNameForUpdate != nil {
-		in, out := &in.LastEndpointConfigNameForUpdate, &out.LastEndpointConfigNameForUpdate
-		*out = new(string)
-		**out = **in
-	}
 	if in.LastModifiedTime != nil {
 		in, out := &in.LastModifiedTime, &out.LastModifiedTime
 		*out = (*in).DeepCopy()
-	}
-	if in.LatestEndpointConfigName != nil {
-		in, out := &in.LatestEndpointConfigName, &out.LatestEndpointConfigName
-		*out = new(string)
-		**out = **in
 	}
 	if in.ProductionVariants != nil {
 		in, out := &in.ProductionVariants, &out.ProductionVariants

--- a/config/crd/bases/sagemaker.services.k8s.aws_endpoints.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_endpoints.yaml
@@ -162,16 +162,9 @@ spec:
                 description: If the status of the endpoint is Failed, the reason why
                   it failed.
                 type: string
-              lastEndpointConfigNameForUpdate:
-                description: Name of the Amazon SageMaker endpoint configuration.
-                type: string
               lastModifiedTime:
                 description: A timestamp that shows when the endpoint was last modified.
                 format: date-time
-                type: string
-              latestEndpointConfigName:
-                description: The name of the endpoint configuration associated with
-                  this endpoint.
                 type: string
               productionVariants:
                 description: An array of ProductionVariantSummary objects, one for

--- a/generator.yaml
+++ b/generator.yaml
@@ -73,7 +73,7 @@ resources:
         - EndpointUpdateError
     hooks:
       sdk_read_one_post_set_output:
-        code: rm.customDescribeEndpointSetOutput(resp, ko)
+        code: rm.customDescribeEndpointSetOutput(ko)
       sdk_update_pre_build_request:
         template_path: endpoint/sdk_update_pre_build_request.go.tpl
       sdk_update_post_set_output:
@@ -96,16 +96,6 @@ resources:
         from:
           operation: DescribeEndpoint
           path: FailureReason
-      LatestEndpointConfigName:
-        is_read_only: true
-        from:
-          operation: DescribeEndpoint
-          path: EndpointConfigName
-      LastEndpointConfigNameForUpdate:
-        is_read_only: true
-        from:
-          operation: DescribeEndpointConfig
-          path: EndpointConfigName
       CreationTime:
         is_read_only: true
         from:

--- a/helm/crds/sagemaker.services.k8s.aws_endpoints.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_endpoints.yaml
@@ -162,16 +162,9 @@ spec:
                 description: If the status of the endpoint is Failed, the reason why
                   it failed.
                 type: string
-              lastEndpointConfigNameForUpdate:
-                description: Name of the Amazon SageMaker endpoint configuration.
-                type: string
               lastModifiedTime:
                 description: A timestamp that shows when the endpoint was last modified.
                 format: date-time
-                type: string
-              latestEndpointConfigName:
-                description: The name of the endpoint configuration associated with
-                  this endpoint.
                 type: string
               productionVariants:
                 description: An array of ProductionVariantSummary objects, one for

--- a/pkg/resource/endpoint/custom_update_conditions.go
+++ b/pkg/resource/endpoint/custom_update_conditions.go
@@ -17,13 +17,15 @@
 package endpoint
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
+
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	svcapitypes "github.com/aws-controllers-k8s/sagemaker-controller/apis/v1alpha1"
 	svccommon "github.com/aws-controllers-k8s/sagemaker-controller/pkg/common"
-	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	corev1 "k8s.io/api/core/v1"
+	
 )
 
 // CustomUpdateConditions sets conditions (terminal) on supplied endpoint.
@@ -46,7 +48,7 @@ func (rm *resourceManager) CustomUpdateConditions(
 	// since desired and latest will be different until the issue is fixed.
 	// Customer can use this condition state and FailureReason to determine
 	// the correct course of action in case the update to Endpoint fails
-	// Customer will also have additional information like latest endpointconfg
+	// Customer will also have additional information like latest endpointConfig
 	// in condition message and last endpointconfig used for update in annotations
 	if err != nil {
 		awsErr, ok := ackerr.AWSError(err)

--- a/pkg/resource/endpoint/custom_update_conditions.go
+++ b/pkg/resource/endpoint/custom_update_conditions.go
@@ -17,9 +17,13 @@
 package endpoint
 
 import (
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	svcapitypes "github.com/aws-controllers-k8s/sagemaker-controller/apis/v1alpha1"
 	svccommon "github.com/aws-controllers-k8s/sagemaker-controller/pkg/common"
+	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // CustomUpdateConditions sets conditions (terminal) on supplied endpoint.
@@ -36,5 +40,21 @@ func (rm *resourceManager) CustomUpdateConditions(
 	resourceName := resourceGK.Kind
 	// If the latestStatus == terminalStatus we will set
 	// the terminal condition and terminal message.
-	return svccommon.SetTerminalState(conditionManager, latestStatus, &resourceName, terminalStatus)
+	updated := svccommon.SetTerminalState(conditionManager, latestStatus, &resourceName, terminalStatus)
+
+	// Continue setting ResourceSynced condition to false in case of failed update
+	// since desired and latest will be different until the issue is fixed.
+	// Customer can use this condition state and FailureReason to determine
+	// the correct course of action in case the update to Endpoint fails
+	// Customer will also have additional information like latest endpointconfg
+	// in condition message and last endpointconfig used for update in annotations
+	if err != nil {
+		awsErr, ok := ackerr.AWSError(err)
+		if ok && awsErr.Code() == "EndpointUpdateError" {
+			ackcondition.SetSynced(conditionManager, corev1.ConditionFalse, aws.String(awsErr.Error()), nil)
+			return true
+		}
+	}
+
+	return updated
 }

--- a/pkg/resource/endpoint/hooks.go
+++ b/pkg/resource/endpoint/hooks.go
@@ -37,7 +37,7 @@ var (
 
 	resourceName = resourceGK.Kind
 
-	lastEndpointConfigForUpdateAnnotation = fmt.Sprintf("%s/%s-last-endpoint-config-for-update", resourceGK.Group, resourceGK.Kind)
+	lastEndpointConfigForUpdateAnnotation = fmt.Sprintf("%s/last-endpoint-config-for-update", resourceGK.Group)
 
 	FailureReasonInternalServiceErrorPrefix = "Request to service failed"
 )
@@ -86,9 +86,9 @@ func (rm *resourceManager) customUpdateEndpointPreChecks(
 
 	failureReason := latest.ko.Status.FailureReason
 	desiredEndpointConfig := desired.ko.Spec.EndpointConfigName
-	
+
 	var lastEndpointConfigForUpdate *string = nil
-	// get last endpoint config name used for udapte form annotation
+	// get last endpoint config name used for update from annotations
 	annotations := desired.ko.ObjectMeta.GetAnnotations()
 	for k, v := range annotations {
 		if k == lastEndpointConfigForUpdateAnnotation {

--- a/pkg/resource/endpoint/sdk.go
+++ b/pkg/resource/endpoint/sdk.go
@@ -157,7 +157,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
-	rm.customDescribeEndpointSetOutput(resp, ko)
+	rm.customDescribeEndpointSetOutput(ko)
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/endpoint/testdata/test_suite.yaml
+++ b/pkg/resource/endpoint/testdata/test_suite.yaml
@@ -145,7 +145,7 @@ tests:
           latest_state: "v1alpha1/update/observed/error_on_update.yaml"
           error: "ServiceUnavailable: Server is down\n\tstatus code: 0, request id: "
       - name: "Update=InService"
-        description: "This test checks if update Endpoint is called and lastEndpointConfigNameForUpdate is set"
+        description: "This test checks if update Endpoint is called and lastEndpointConfigNameForUpdate annotation is set"
         given:
           desired_state: "v1alpha1/update/desired/update_common.yaml"
           latest_state: "v1alpha1/update/desired/latest_inservice_pre_update.yaml"

--- a/pkg/resource/endpoint/testdata/v1alpha1/readone/desired/after_update_apicall_success.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/readone/desired/after_update_apicall_success.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   name: xgboost-endpoint
   annotations:
-    sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
+    sagemaker.services.k8s.aws/last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
 spec:
   endpointConfigName: xgboost-endpoint-variant-config-updated
   endpointName: xgboost-endpoint

--- a/pkg/resource/endpoint/testdata/v1alpha1/readone/desired/after_update_apicall_success.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/readone/desired/after_update_apicall_success.yaml
@@ -3,8 +3,10 @@ kind: Endpoint
 metadata:
   creationTimestamp: null
   name: xgboost-endpoint
+  annotations:
+    sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
 spec:
-  endpointConfigName: xgboost-endpoint-multi-variant-config
+  endpointConfigName: xgboost-endpoint-variant-config-updated
   endpointName: xgboost-endpoint
   tags:
   - key: confidentiality
@@ -25,8 +27,6 @@ status:
   creationTime: "0001-01-01T00:00:00Z"
   endpointStatus: InService
   lastModifiedTime: "0001-01-01T00:00:00Z"
-  latestEndpointConfigName: xgboost-endpoint-single-variant-config
-  lastEndpointConfigNameForUpdate: xgboost-endpoint-multi-variant-config
   productionVariants:
   - currentInstanceCount: 2
     currentWeight: 1

--- a/pkg/resource/endpoint/testdata/v1alpha1/readone/observed/creating_after_describe.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/readone/observed/creating_after_describe.yaml
@@ -25,4 +25,3 @@ status:
   creationTime: "0001-01-01T00:00:00Z"
   endpointStatus: Creating
   lastModifiedTime: "0001-01-01T00:00:00Z"
-  latestEndpointConfigName: xgboost-endpoint-single-variant-config

--- a/pkg/resource/endpoint/testdata/v1alpha1/readone/observed/failed_status_on_describe.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/readone/observed/failed_status_on_describe.yaml
@@ -30,4 +30,3 @@ status:
   endpointStatus: Failed
   failureReason: ' Failed to download model data for container from URL, blah'
   lastModifiedTime: "0001-01-01T00:00:00Z"
-  latestEndpointConfigName: xgboost-endpoint-faulty-config

--- a/pkg/resource/endpoint/testdata/v1alpha1/readone/observed/inservice_no_failure_after_describe.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/readone/observed/inservice_no_failure_after_describe.yaml
@@ -25,7 +25,6 @@ status:
   creationTime: "0001-01-01T00:00:00Z"
   endpointStatus: InService
   lastModifiedTime: "0001-01-01T00:00:00Z"
-  latestEndpointConfigName: xgboost-endpoint-single-variant-config
   productionVariants:
   - currentInstanceCount: 2
     currentWeight: 1

--- a/pkg/resource/endpoint/testdata/v1alpha1/readone/observed/updating_on_describe.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/readone/observed/updating_on_describe.yaml
@@ -1,6 +1,8 @@
 apiVersion: sagemaker.services.k8s.aws/v1alpha1
 kind: Endpoint
 metadata:
+  annotations:
+    sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
   creationTimestamp: null
   name: xgboost-endpoint
 spec:
@@ -24,9 +26,7 @@ status:
     type: ACK.ResourceSynced
   creationTime: "0001-01-01T00:00:00Z"
   endpointStatus: Updating
-  lastEndpointConfigNameForUpdate: xgboost-endpoint-multi-variant-config
   lastModifiedTime: "0001-01-01T00:00:00Z"
-  latestEndpointConfigName: xgboost-endpoint-single-variant-config
   productionVariants:
   - currentInstanceCount: 2
     currentWeight: 1

--- a/pkg/resource/endpoint/testdata/v1alpha1/readone/observed/updating_on_describe.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/readone/observed/updating_on_describe.yaml
@@ -2,7 +2,7 @@ apiVersion: sagemaker.services.k8s.aws/v1alpha1
 kind: Endpoint
 metadata:
   annotations:
-    sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
+    sagemaker.services.k8s.aws/last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
   creationTimestamp: null
   name: xgboost-endpoint
 spec:

--- a/pkg/resource/endpoint/testdata/v1alpha1/update/desired/inservice_post_update_fail.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/update/desired/inservice_post_update_fail.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   name: xgboost-endpoint
   annotations:
-    sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
+    sagemaker.services.k8s.aws/last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
 spec:
   endpointConfigName: xgboost-endpoint-single-variant-config-updated
   endpointName: xgboost-endpoint

--- a/pkg/resource/endpoint/testdata/v1alpha1/update/desired/inservice_post_update_fail.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/update/desired/inservice_post_update_fail.yaml
@@ -3,6 +3,8 @@ kind: Endpoint
 metadata:
   creationTimestamp: null
   name: xgboost-endpoint
+  annotations:
+    sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
 spec:
   endpointConfigName: xgboost-endpoint-single-variant-config-updated
   endpointName: xgboost-endpoint
@@ -13,13 +15,11 @@ status:
   conditions:
   - lastTransitionTime: "0001-01-01T00:00:00.109Z"
     message: Endpoint is in InService status.
-    status: "True"
+    status: "False"
     type: ACK.ResourceSynced
   creationTime: "0001-01-01T00:00:00.109Z"
   endpointStatus: InService
-  lastEndpointConfigNameForUpdate: xgboost-endpoint-single-variant-config-updated
   lastModifiedTime: "0001-01-01T00:00:00.109Z"
-  latestEndpointConfigName: xgboost-endpoint-single-variant-config
   productionVariants:
   - currentInstanceCount: 2
     currentWeight: 1

--- a/pkg/resource/endpoint/testdata/v1alpha1/update/desired/latest_update_failed_with_reason.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/update/desired/latest_update_failed_with_reason.yaml
@@ -2,7 +2,7 @@ apiVersion: sagemaker.services.k8s.aws/v1alpha1
 kind: Endpoint
 metadata:
   annotations:
-    sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
+    sagemaker.services.k8s.aws/last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
   creationTimestamp: null
   name: xgboost-endpoint
 spec:

--- a/pkg/resource/endpoint/testdata/v1alpha1/update/desired/latest_update_failed_with_reason.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/update/desired/latest_update_failed_with_reason.yaml
@@ -1,6 +1,8 @@
 apiVersion: sagemaker.services.k8s.aws/v1alpha1
 kind: Endpoint
 metadata:
+  annotations:
+    sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
   creationTimestamp: null
   name: xgboost-endpoint
 spec:
@@ -19,8 +21,6 @@ status:
   endpointStatus: InService
   lastModifiedTime: "0001-01-01T00:00:00.109Z"
   failureReason: ' Failed to download model data for container from URL, blah'
-  lastEndpointConfigNameForUpdate: xgboost-endpoint-single-variant-config-updated
-  latestEndpointConfigName: xgboost-endpoint-single-variant-config
   productionVariants:
   - currentInstanceCount: 2
     currentWeight: 1

--- a/pkg/resource/endpoint/testdata/v1alpha1/update/desired/latest_updating.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/update/desired/latest_updating.yaml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   name: xgboost-endpoint
   annotations:
-    sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
+    sagemaker.services.k8s.aws/last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
 spec:
   endpointConfigName: xgboost-endpoint-single-variant-config
   endpointName: xgboost-endpoint

--- a/pkg/resource/endpoint/testdata/v1alpha1/update/desired/latest_updating.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/update/desired/latest_updating.yaml
@@ -3,6 +3,8 @@ kind: Endpoint
 metadata:
   creationTimestamp: null
   name: xgboost-endpoint
+  annotations:
+    sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
 spec:
   endpointConfigName: xgboost-endpoint-single-variant-config
   endpointName: xgboost-endpoint
@@ -17,9 +19,7 @@ status:
     type: ACK.ResourceSynced
   creationTime: "0001-01-01T00:00:00Z"
   endpointStatus: Updating
-  lastEndpointConfigNameForUpdate: xgboost-endpoint-single-variant-config-updated
   lastModifiedTime: "0001-01-01T00:00:00Z"
-  latestEndpointConfigName: xgboost-endpoint-single-variant-config
   productionVariants:
   - currentInstanceCount: 2
     currentWeight: 1

--- a/pkg/resource/endpoint/testdata/v1alpha1/update/observed/error_on_update.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/update/observed/error_on_update.yaml
@@ -21,7 +21,6 @@ status:
   creationTime: "0001-01-01T00:00:00Z"
   endpointStatus: InService
   lastModifiedTime: "0001-01-01T00:00:00Z"
-  latestEndpointConfigName: xgboost-endpoint-single-variant-config
   productionVariants:
   - currentInstanceCount: 2
     currentWeight: 1

--- a/pkg/resource/endpoint/testdata/v1alpha1/update/observed/no_retry_on_failed_update.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/update/observed/no_retry_on_failed_update.yaml
@@ -2,7 +2,7 @@ apiVersion: sagemaker.services.k8s.aws/v1alpha1
 kind: Endpoint
 metadata:
   annotations:
-    sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
+    sagemaker.services.k8s.aws/last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
   creationTimestamp: null
   name: xgboost-endpoint
 spec:
@@ -18,8 +18,8 @@ status:
       latest EndpointConfigName is xgboost-endpoint-single-variant-config'
     status: "False"
     type: ACK.ResourceSynced
-  - message: unable to update endpoint. check FailureReason. latest EndpointConfigName
-      is xgboost-endpoint-single-variant-config
+  - message: 'EndpointUpdateError: unable to update endpoint. check FailureReason.
+      latest EndpointConfigName is xgboost-endpoint-single-variant-config'
     status: "True"
     type: ACK.Terminal
   creationTime: "0001-01-01T00:00:00Z"

--- a/pkg/resource/endpoint/testdata/v1alpha1/update/observed/no_retry_on_failed_update.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/update/observed/no_retry_on_failed_update.yaml
@@ -1,6 +1,8 @@
 apiVersion: sagemaker.services.k8s.aws/v1alpha1
 kind: Endpoint
 metadata:
+  annotations:
+    sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
   creationTimestamp: null
   name: xgboost-endpoint
 spec:
@@ -12,18 +14,18 @@ status:
     ownerAccountID: ""
   conditions:
   - lastTransitionTime: "0001-01-01T00:00:00Z"
-    message: Endpoint is in InService status.
-    status: "True"
+    message: 'EndpointUpdateError: unable to update endpoint. check FailureReason.
+      latest EndpointConfigName is xgboost-endpoint-single-variant-config'
+    status: "False"
     type: ACK.ResourceSynced
-  - message: 'EndpointUpdateError: unable to update endpoint. check FailureReason'
+  - message: unable to update endpoint. check FailureReason. latest EndpointConfigName
+      is xgboost-endpoint-single-variant-config
     status: "True"
     type: ACK.Terminal
   creationTime: "0001-01-01T00:00:00Z"
   endpointStatus: InService
   failureReason: ' Failed to download model data for container from URL, blah'
-  lastEndpointConfigNameForUpdate: xgboost-endpoint-single-variant-config-updated
   lastModifiedTime: "0001-01-01T00:00:00Z"
-  latestEndpointConfigName: xgboost-endpoint-single-variant-config
   productionVariants:
   - currentInstanceCount: 2
     currentWeight: 1

--- a/pkg/resource/endpoint/testdata/v1alpha1/update/observed/no_update_on_failed.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/update/observed/no_update_on_failed.yaml
@@ -17,8 +17,8 @@ status:
     status: "False"
     type: ACK.ResourceSynced
   - lastTransitionTime: "0001-01-01T00:00:00Z"
-    message: unable to update endpoint. check FailureReason. latest EndpointConfigName
-      is xgboost-endpoint-single-variant-config
+    message: 'EndpointUpdateError: unable to update endpoint. check FailureReason.
+      latest EndpointConfigName is xgboost-endpoint-single-variant-config'
     status: "True"
     type: ACK.Terminal
   creationTime: "0001-01-01T00:00:00Z"

--- a/pkg/resource/endpoint/testdata/v1alpha1/update/observed/no_update_on_failed.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/update/observed/no_update_on_failed.yaml
@@ -12,15 +12,16 @@ status:
     ownerAccountID: ""
   conditions:
   - lastTransitionTime: "0001-01-01T00:00:00Z"
-    message: Endpoint is in Failed status.
-    status: "True"
+    message: 'EndpointUpdateError: unable to update endpoint. check FailureReason.
+      latest EndpointConfigName is xgboost-endpoint-single-variant-config'
+    status: "False"
     type: ACK.ResourceSynced
   - lastTransitionTime: "0001-01-01T00:00:00Z"
-    message: 'EndpointUpdateError: unable to update endpoint. check FailureReason'
+    message: unable to update endpoint. check FailureReason. latest EndpointConfigName
+      is xgboost-endpoint-single-variant-config
     status: "True"
     type: ACK.Terminal
   creationTime: "0001-01-01T00:00:00Z"
   endpointStatus: Failed
   failureReason: ' Failed to download model data for container from URL, blah'
   lastModifiedTime: "0001-01-01T00:00:00Z"
-  latestEndpointConfigName: xgboost-endpoint-single-variant-config

--- a/pkg/resource/endpoint/testdata/v1alpha1/update/observed/update_attempted_success.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/update/observed/update_attempted_success.yaml
@@ -2,7 +2,7 @@ apiVersion: sagemaker.services.k8s.aws/v1alpha1
 kind: Endpoint
 metadata:
   annotations:
-    sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
+    sagemaker.services.k8s.aws/last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
   creationTimestamp: null
   name: xgboost-endpoint
 spec:

--- a/pkg/resource/endpoint/testdata/v1alpha1/update/observed/update_attempted_success.yaml
+++ b/pkg/resource/endpoint/testdata/v1alpha1/update/observed/update_attempted_success.yaml
@@ -1,6 +1,8 @@
 apiVersion: sagemaker.services.k8s.aws/v1alpha1
 kind: Endpoint
 metadata:
+  annotations:
+    sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update: xgboost-endpoint-single-variant-config-updated
   creationTimestamp: null
   name: xgboost-endpoint
 spec:
@@ -17,9 +19,7 @@ status:
     type: ACK.ResourceSynced
   creationTime: "0001-01-01T00:00:00Z"
   endpointStatus: Updating
-  lastEndpointConfigNameForUpdate: xgboost-endpoint-single-variant-config-updated
   lastModifiedTime: "0001-01-01T00:00:00Z"
-  latestEndpointConfigName: xgboost-endpoint-single-variant-config
   productionVariants:
   - currentInstanceCount: 2
     currentWeight: 1

--- a/test/e2e/tests/test_endpoint.py
+++ b/test/e2e/tests/test_endpoint.py
@@ -34,7 +34,8 @@ from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e.common import config as cfg
 
 FAIL_UPDATE_ERROR_MESSAGE = "EndpointUpdateError: unable to update endpoint. check FailureReason. latest EndpointConfigName is "
-LAST_ENDPOINTCONFIGNNAME_FOR_UPDATE_ANNOTATION_KEY = "sagemaker.services.k8s.aws/Endpoint-last-endpoint-config-for-update"
+# annontation key for last endpoint config name used for update
+LAST_ENDPOINTCONFIG_UPDATE_ANNOTATION = "sagemaker.services.k8s.aws/last-endpoint-config-for-update"
 
 @pytest.fixture(scope="module")
 def name_suffix():
@@ -275,7 +276,7 @@ class TestEndpoint:
         endpoint_resource = k8s.get_resource(endpoint_reference)
         annotations = endpoint_resource["metadata"].get("annotations", None)
         assert annotations is not None
-        assert annotations[LAST_ENDPOINTCONFIGNNAME_FOR_UPDATE_ANNOTATION_KEY] == faulty_config_name
+        assert annotations[LAST_ENDPOINTCONFIG_UPDATE_ANNOTATION] == faulty_config_name
 
         assert_endpoint_status_in_sync(
             endpoint_reference.name, endpoint_reference, cfg.ENDPOINT_STATUS_INSERVICE,
@@ -323,7 +324,7 @@ class TestEndpoint:
         endpoint_resource = k8s.get_resource(endpoint_reference)
         annotations = endpoint_resource["metadata"].get("annotations", None)
         assert annotations is not None
-        assert annotations[LAST_ENDPOINTCONFIGNNAME_FOR_UPDATE_ANNOTATION_KEY] == new_config_name
+        assert annotations[LAST_ENDPOINTCONFIG_UPDATE_ANNOTATION] == new_config_name
 
         assert_endpoint_status_in_sync(
             endpoint_reference.name, endpoint_reference, cfg.ENDPOINT_STATUS_INSERVICE,


### PR DESCRIPTION
Description of changes:
1. Remove `status.latestEndpointConfgName` from CRD
  - This field was added for customers to have a reliable way to wait for a successful update because the endpoint goes back to `InService` even after a failed update and the `ResourceSynced` condition was set to `True`. 
  - A customer could not rely on `ResourceSynced` or `endpointStatus` to get the accurate picture and they needed do multiple checks the update is successful.
    -  e.g. `endpointStatus == InService && ACK.ResourceSynced == true && ACK.Terminal == False && failureReason = nil`.
    - To simplify this, latestEndpointConfig was added to the status so Cx can wait on just `spec.EndpointConfigName == status.latestEndpointConfigName`
  - With this change, the `ResourceSynced` condition will not go to `True` on failed update since the desired state cannot be reached. Customers can just wait and timeout on:
    - `endpointStatus == InService && ACK.ResourceSynced == true` and check for failure reason in case of timeout. The latestEndpointConfig from service will be in the Terminal condition message for convinence
2. Move `status.lastEndpointConfigForUpdate` to metadata
  - This is purely a metadata field. It was only required by the controller to stop retrying an update and hence has been moved to annotation.
  - Moving this to annotations gives us a two-way door. In case we find a better heuristic in future to differentiate between update related error and related to service modification, this can be removed easily with having any backward breaking changes to the CRD

Testing:
```
pytest tests/test_endpoint.py
```
PR build will pass after #91  is merged since there is a dependency on the error message

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
