### PR TITLE
release artifacts for release v0.0.4

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,14 +1,14 @@
 ack_generate_info:
-  build_date: "2021-09-01T08:44:58Z"
-  build_hash: 07d7ea755625b2cac93bbf293bf5a8cab24ecb68
+  build_date: "2021-09-01T20:02:38Z"
+  build_hash: 709a1e110beb1da248c87c7738f97282d90556ba
   go_version: go1.16.4 linux/amd64
   version: v0.13.0
-api_directory_checksum: a0f6457435f0a16addd9cf7d0acef2830722bd78
+api_directory_checksum: 48052ad31bd7f3dbf811d81079f7235446af4cfc
 api_version: v1alpha1
 aws_sdk_go_version: v1.38.11
 generator_config_info:
-  file_checksum: 8624689ea5b08289d25ad897c5f8cf5afc96b0ea
+  file_checksum: 0a6535a29c6f76b5ce8a9d15f6de246542a017d8
   original_file_name: generator.yaml
 last_modification:
   reason: API generation
-  timestamp: 2021-09-01 08:45:01.42242216 +0000 UTC
+  timestamp: 2021-09-01 20:02:43.411194445 +0000 UTC

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: sagemaker-chart
 description: A Helm chart for the ACK service controller for Amazon SageMaker (SageMaker)
-version: v0.0.3
-appVersion: v0.0.3
+version: v0.0.4
+appVersion: v0.0.4
 home: https://github.com/aws-controllers-k8s/sagemaker-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/sagemaker-controller
-  tag: v0.0.3
+  tag: v0.0.4
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/pkg/resource/endpoint/custom_update_conditions.go
+++ b/pkg/resource/endpoint/custom_update_conditions.go
@@ -21,11 +21,10 @@ import (
 
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	svcapitypes "github.com/aws-controllers-k8s/sagemaker-controller/apis/v1alpha1"
 	svccommon "github.com/aws-controllers-k8s/sagemaker-controller/pkg/common"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	
+	corev1 "k8s.io/api/core/v1"
 )
 
 // CustomUpdateConditions sets conditions (terminal) on supplied endpoint.

--- a/pkg/resource/model_package/resource.go
+++ b/pkg/resource/model_package/resource.go
@@ -97,11 +97,6 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	}
 	r.ko.Status.ACKResourceMetadata.ARN = identifier.ARN
 
-	f0, f0ok := identifier.AdditionalKeys["modelPackageName"]
-	if f0ok {
-		r.ko.Spec.ModelPackageName = &f0
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Description of changes:
- release artifacts for 0.0.4
- bring in latest code generator changes and a minor go fmt fix

Release notes draft:

This release includes the following resources and updates:
- NotebookInstance
- NotebookInstanceLifecycleConfig
- TrainingJob
  - Requeue until profiler rule evaluation is complete
  - Model Artifact location in the status
- Endpoint 
  - Remove `status.latestEndpointConfgName` and  ([#92](https://github.com/aws-controllers-k8s/sagemaker-controller/pull/92))
  - Move `status.lastEndpointConfigForUpdate` to annotations

Requeue until job stopped
Reuqueue unil resource is removed from service side
Update runtime 0.13.0

Update conditions on delete

Model package
- Enabled Versiooned model package
- Enable adopted resource
- 
Testing:
PR build

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
