### PR TITLE
unit tests for notebook lifecycle instance

### DIFF
--- a/pkg/resource/notebook_instance_lifecycle_config/manager_test_suite_test.go
+++ b/pkg/resource/notebook_instance_lifecycle_config/manager_test_suite_test.go
@@ -1,0 +1,137 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package notebook_instance_lifecycle_config
+
+import (
+	"errors"
+	"fmt"
+
+	"path/filepath"
+	"testing"
+
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
+	svcapitypes "github.com/aws-controllers-k8s/sagemaker-controller/apis/v1alpha1"
+	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
+	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
+	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/ghodss/yaml"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.uber.org/zap/zapcore"
+	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// provideResourceManagerWithMockSDKAPI accepts MockSageMakerAPI and returns pointer to resourceManager
+// the returned resourceManager is configured to use mockapi api.
+func provideResourceManagerWithMockSDKAPI(mockSageMakerAPI *mocksvcsdkapi.SageMakerAPI) *resourceManager {
+	zapOptions := ctrlrtzap.Options{
+		Development: true,
+		Level:       zapcore.InfoLevel,
+	}
+	fakeLogger := ctrlrtzap.New(ctrlrtzap.UseFlagOptions(&zapOptions))
+	return &resourceManager{
+		rr:           nil,
+		awsAccountID: "",
+		awsRegion:    "",
+		sess:         nil,
+		sdkapi:       mockSageMakerAPI,
+		log:          fakeLogger,
+		metrics:      ackmetrics.NewMetrics("sagemaker"),
+	}
+}
+
+// TestNotebookInstanceLifecycleConfigTestSuite runs the test suite for notebook instance lifecycle config
+func TestNotebookInstanceLifeCycleConfigTestSuite(t *testing.T) {
+	var ts = testutil.TestSuite{}
+	testutil.LoadFromFixture(filepath.Join("testdata", "test_suite.yaml"), &ts)
+	var delegate = testRunnerDelegate{t: t}
+	var runner = testutil.TestSuiteRunner{TestSuite: &ts, Delegate: &delegate}
+	runner.RunTests()
+}
+
+// testRunnerDelegate implements testutil.TestRunnerDelegate
+type testRunnerDelegate struct {
+	t *testing.T
+}
+
+func (d *testRunnerDelegate) ResourceDescriptor() acktypes.AWSResourceDescriptor {
+	return &resourceDescriptor{}
+}
+
+func (d *testRunnerDelegate) ResourceManager(mocksdkapi *mocksvcsdkapi.SageMakerAPI) acktypes.AWSResourceManager {
+	return provideResourceManagerWithMockSDKAPI(mocksdkapi)
+}
+
+func (d *testRunnerDelegate) GoTestRunner() *testing.T {
+	return d.t
+}
+
+func (d *testRunnerDelegate) EmptyServiceAPIOutput(apiName string) (interface{}, error) {
+	if apiName == "" {
+		return nil, errors.New("no API name specified")
+	}
+	//TODO: use reflection, template to auto generate this block/method.
+	switch apiName {
+	case "CreateNotebookInstanceLifecycleConfigWithContext":
+		var output svcsdk.CreateNotebookInstanceLifecycleConfigOutput
+		return &output, nil
+	case "DescribeNotebookInstanceLifecycleConfigWithContext":
+		var output svcsdk.DescribeNotebookInstanceLifecycleConfigOutput
+		return &output, nil
+	case "DeleteNotebookInstanceLifecycleConfigWithContext":
+		var output svcsdk.DeleteNotebookInstanceLifecycleConfigOutput
+		return &output, nil
+	}
+	return nil, errors.New(fmt.Sprintf("no matching API name found for: %s", apiName))
+}
+
+func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResource) bool {
+	ac := a.(*resource)
+	bc := b.(*resource)
+	// Ignore LastTransitionTime since it gets updated each run.
+	opts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.IgnoreFields(ackv1alpha1.Condition{}, "LastTransitionTime"),
+		cmpopts.IgnoreFields(svcapitypes.NotebookInstanceLifecycleConfigStatus{}, "CreationTime"),
+		cmpopts.IgnoreFields(svcapitypes.NotebookInstanceLifecycleConfigStatus{}, "LastModifiedTime")}
+
+	var specMatch = false
+	if cmp.Equal(ac.ko.Spec, bc.ko.Spec, opts...) {
+		specMatch = true
+	} else {
+		fmt.Printf("Difference ko.Spec (-expected +actual):\n\n")
+		fmt.Println(cmp.Diff(ac.ko.Spec, bc.ko.Spec, opts...))
+		specMatch = false
+	}
+
+	var statusMatch = false
+	if cmp.Equal(ac.ko.Status, bc.ko.Status, opts...) {
+		statusMatch = true
+	} else {
+		fmt.Printf("Difference ko.Status (-expected +actual):\n\n")
+		fmt.Println(cmp.Diff(ac.ko.Status, bc.ko.Status, opts...))
+		statusMatch = false
+	}
+
+	return statusMatch && specMatch
+}
+
+// Checks to see if the given yaml file, with name stored as expectation,
+// matches the yaml marshal of the AWSResource stored as actual.
+func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
+	// Build a tmp file for the actual yaml.
+	actualResource := actual.(*resource)
+	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
+	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
+}

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/sdkapi/create/create_success.json
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/sdkapi/create/create_success.json
@@ -1,0 +1,3 @@
+{
+    "NotebookInstanceLifecycleConfigArn": "arn:aws:sagemaker:us-west-2:123456789012:notebook-instance-lifecycle-config/unit-testing-notebook-instance-lifecycle-config"
+}

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/sdkapi/describe/success_describe.json
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/sdkapi/describe/success_describe.json
@@ -1,0 +1,16 @@
+{
+    "CreationTime": "2021-09-22T06:13:00.841Z",
+    "LastModifiedTime": "2021-09-22T06:13:00.841Z",
+    "NotebookInstanceLifecycleConfigArn": "arn:aws:sagemaker:us-west-2:123456789012:notebook-instance-lifecycle-config/unit-testing-notebook-instance-lifecycle-config",
+    "NotebookInstanceLifecycleConfigName": "unit-testing-notebook-instance-lifecycle-config",
+    "OnCreate": [
+        {
+            "Content": "ZWNobyAiRW50ZXJpbmcgb25DcmVhdGUi"
+        }
+    ],
+    "OnStart": [
+        {
+            "Content": "ZWNobyAiRW50ZXJpbmcgb25TdGFydCI="
+        }
+    ]
+}

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/test_suite.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/test_suite.yaml
@@ -1,0 +1,135 @@
+tests:
+  - name: "Notebook instance lifecycle config create tests"
+    description: "Testing create operation"
+    scenarios:
+      - name: "Create=InvalidInput"
+        description: "Given one of the parameters is invalid, ko.Status shows a terminal condition"
+        given:
+          desired_state: "v1alpha1/create/desired/invalid_before_create.yaml"
+          svc_api:
+            - operation: CreateNotebookInstanceLifecycleConfigWithContext
+              error:
+                code: InvalidParameterValue
+                message: "The notebook instance lifecycle config name must not include a special character."
+        invoke: Create
+        expect:
+          latest_state: "v1alpha1/create/observed/invalid_create_attempted.yaml"
+          error: resource is in terminal condition
+      - name: "Create=Valid"
+        description: "Create a new notebook instance lifecycle config successfully (ARN in status)."
+        given:
+          desired_state: "v1alpha1/create/desired/success_before_create.yaml"
+          svc_api:
+            - operation: CreateNotebookInstanceLifecycleConfigWithContext
+              output_fixture: "sdkapi/create/create_success.json"
+        invoke: Create
+        expect:
+          latest_state: "v1alpha1/create/observed/success_after_create.yaml"
+          error: nil
+  - name: "Notebook instance lifecycle config readOne tests"
+    description: "Testing the readOne operation"
+    scenarios:
+      - name: "ReadOne=MissingRequiredField"
+        description: "Testing readOne when required field is missing. No API call is made and returns error."
+        given: 
+          desired_state: "v1alpha1/readone/desired/missing_required_field.yaml"
+        invoke: ReadOne
+        expect:
+          error: "resource not found"
+      - name: "ReadOne=SuccessClearsConditions"
+        description: Testing a successful reconciliation clears conditions if terminal/recoverable condition were already set to true
+        given:
+          desired_state: "v1alpha1/readone/desired/error_conditions_true.yaml"
+          svc_api:
+            - operation: DescribeNotebookInstanceLifecycleConfigWithContext
+              output_fixture: "sdkapi/describe/success_describe.json"
+        invoke: ReadOne
+        expect:
+          latest_state: "v1alpha1/readone/observed/conditions_clear_on_success.yaml"
+      - name: "ReadOne=NotFound"
+        description: "Testing readOne when Describe fails to find the resource on SageMaker"
+        given: 
+          desired_state: "v1alpha1/readone/desired/right_after_create.yaml"
+          svc_api:
+            - operation: DescribeNotebookInstanceLifecycleConfigWithContext
+              error:
+                code: ValidationException
+                message: "Unable to describe Notebook Instance Lifecycle Config unit-testing-notebook-instance-lifecycle-config"
+        invoke: ReadOne
+        expect:
+          error: "resource not found"
+      - name: "ReadOne=Fail"
+        description: "This test checks if the condition is updated if describe fails and readOne returns error"
+        given: 
+          desired_state: "v1alpha1/readone/desired/right_after_create.yaml"
+          svc_api:
+            - operation: DescribeNotebookInstanceLifecycleConfigWithContext
+              error:
+                code: ServiceUnavailable
+                message: "Server is down"
+        invoke: ReadOne
+        expect:
+          latest_state: "v1alpha1/readone/observed/error_on_describe.yaml"
+          error: "ServiceUnavailable: Server is down\n\tstatus code: 0, request id: "
+      - name: "ReadOne=AfterCreate"
+        description: "Testing readOne right after create"
+        given:
+          desired_state: "v1alpha1/readone/desired/right_after_create.yaml"
+          svc_api:
+            - operation: DescribeNotebookInstanceLifecycleConfigWithContext
+              output_fixture: "sdkapi/describe/success_describe.json"
+        invoke: ReadOne
+        expect:
+          latest_state: "v1alpha1/readone/observed/creating_after_describe.yaml"
+  - name: "Notebook instance lifecycle config update tests"
+    description: "Testing the Update operation"
+    scenarios:
+      - name: "Update=StatusUpdating"
+        description: "This test checks if the notebook instance lifecycle config requeues after Updating "
+        given:
+          desired_state: "v1alpha1/update/desired/update_common.yaml"
+          latest_state: "v1alpha1/update/desired/update_common.yaml"
+          svc_api:
+            - operation: UpdateNotebookInstanceLifecycleConfigWithContext
+        invoke: Update
+        expect:
+          latest_state: "v1alpha1/update/observed/update_attempted_success.yaml"
+          error: NotebookInstanceLifecycleConfig is updating.
+      - name: "Update=Fail"
+        description: "This test checks if the recoverable condition is updated if update fails and returns error"
+        given:
+          desired_state: "v1alpha1/update/desired/update_common.yaml"
+          latest_state: "v1alpha1/readone/desired/right_after_create.yaml"
+          svc_api:
+            - operation: UpdateNotebookInstanceLifecycleConfigWithContext
+              error:
+                code: ServiceUnavailable
+                message: "Server is down"
+        invoke: Update
+        expect:
+          latest_state: "v1alpha1/update/observed/error_on_update.yaml"
+          error: "ServiceUnavailable: Server is down\n\tstatus code: 0, request id: "
+  - name: "Notebook instance lifecycle config delete tests"
+    description: "Testing the delete operation"
+    scenarios:
+      - name: "Delete=Fail"
+        description: "This test checks if the condition is updated if delete fails and returns error"
+        given:
+          desired_state: "v1alpha1/delete/desired/inservice_before_delete.yaml"
+          svc_api:
+            - operation: DeleteNotebookInstanceLifecycleConfigWithContext
+              error:
+                code: ServiceUnavailable
+                message: "Server is down"
+        invoke: Delete
+        expect:
+          error: "ServiceUnavailable: Server is down\n\tstatus code: 0, request id: "
+      - name: "Delete=Successful"
+        description: "This test checks if the notebook instance lifecycle config is deleted successfully"
+        given:
+          desired_state: "v1alpha1/delete/desired/inservice_before_delete.yaml"
+          svc_api:
+            - operation: DeleteNotebookInstanceLifecycleConfigWithContext
+        invoke: Delete
+        expect:
+          error: nil

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/create/desired/invalid_before_create.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/create/desired/invalid_before_create.yaml
@@ -1,0 +1,10 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: NotebookInstanceLifecycleConfig
+metadata:
+  name: unit-testing-notebook-instance-lifecycle-config
+spec:
+  notebookInstanceLifecycleConfigName: intentionally@invalid-name
+  onStart:
+    - content: ZWNobyAiRW50ZXJpbmcgb25TdGFydCI=
+  onCreate:
+    - content: ZWNobyAiRW50ZXJpbmcgb25DcmVhdGUi

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/create/desired/success_before_create.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/create/desired/success_before_create.yaml
@@ -1,0 +1,10 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: NotebookInstanceLifecycleConfig
+metadata:
+  name: unit-testing-notebook-instance-lifecycle-config
+spec:
+  notebookInstanceLifecycleConfigName: unit-testing-notebook-instance-lifecycle-config
+  onStart:
+    - content: ZWNobyAiRW50ZXJpbmcgb25TdGFydCI=
+  onCreate:
+    - content: ZWNobyAiRW50ZXJpbmcgb25DcmVhdGUi

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/create/observed/invalid_create_attempted.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/create/observed/invalid_create_attempted.yaml
@@ -1,0 +1,19 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: NotebookInstanceLifecycleConfig
+metadata:
+  creationTimestamp: null
+  name: unit-testing-notebook-instance-lifecycle-config
+spec:
+  notebookInstanceLifecycleConfigName: intentionally@invalid-name
+  onCreate:
+  - content: ZWNobyAiRW50ZXJpbmcgb25DcmVhdGUi
+  onStart:
+  - content: ZWNobyAiRW50ZXJpbmcgb25TdGFydCI=
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: "InvalidParameterValue: The notebook instance lifecycle config name must
+      not include a special character.\n\tstatus code: 0, request id: "
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/create/observed/success_after_create.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/create/observed/success_after_create.yaml
@@ -1,0 +1,16 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: NotebookInstanceLifecycleConfig
+metadata:
+  creationTimestamp: null
+  name: unit-testing-notebook-instance-lifecycle-config
+spec:
+  notebookInstanceLifecycleConfigName: unit-testing-notebook-instance-lifecycle-config
+  onCreate:
+  - content: ZWNobyAiRW50ZXJpbmcgb25DcmVhdGUi
+  onStart:
+  - content: ZWNobyAiRW50ZXJpbmcgb25TdGFydCI=
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:notebook-instance-lifecycle-config/unit-testing-notebook-instance-lifecycle-config
+    ownerAccountID: ""
+  conditions: []

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/delete/desired/inservice_before_delete.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/delete/desired/inservice_before_delete.yaml
@@ -1,0 +1,20 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: NotebookInstanceLifecycleConfig
+metadata:
+  creationTimestamp: null
+  name: unit-testing-notebook-instance-lifecycle-config
+spec:
+  notebookInstanceLifecycleConfigName: unit-testing-notebook-instance-lifecycle-config
+  onCreate:
+  - content: ZWNobyAiRW50ZXJpbmcgb25DcmVhdGUi
+  onStart:
+  - content: ZWNobyAiRW50ZXJpbmcgb25TdGFydCI=
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:notebook-instance-lifecycle-config/unit-testing-notebook-instance-lifecycle-config
+    ownerAccountID: ""
+  conditions:
+  - status: "True"
+    type: ACK.ResourceSynced
+  creationTime: "0001-01-01T00:00:00Z"
+  lastModifiedTime: "0001-01-01T00:00:00Z"

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/readone/desired/error_conditions_true.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/readone/desired/error_conditions_true.yaml
@@ -1,0 +1,19 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: NotebookInstanceLifecycleConfig
+metadata:
+  creationTimestamp: null
+  name: unit-testing-notebook-instance-lifecycle-config
+spec:
+  notebookInstanceLifecycleConfigName: intentionally@invalid-name
+  onCreate:
+  - content: ZWNobyAiRW50ZXJpbmcgb25DcmVhdGUi
+  onStart:
+  - content: ZWNobyAiRW50ZXJpbmcgb25TdGFydCI=
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: "InvalidParameterValue: The notebook instance lifecycle config name must
+      not include a special character.\n\tstatus code: 0, request id: "
+    status: "True"
+    type: ACK.Terminal

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/readone/desired/missing_required_field.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/readone/desired/missing_required_field.yaml
@@ -1,0 +1,10 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: NotebookInstanceLifecycleConfig
+metadata:
+  name: unit-testing-notebook-instance-lifecycle-config
+spec:
+  # missing notebookInstanceLifecycleConfigName
+  onStart:
+    - content: ZWNobyAiRW50ZXJpbmcgb25TdGFydCI=
+  onCreate:
+    - content: ZWNobyAiRW50ZXJpbmcgb25DcmVhdGUi

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/readone/desired/right_after_create.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/readone/desired/right_after_create.yaml
@@ -1,0 +1,19 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: NotebookInstanceLifecycleConfig
+metadata:
+  creationTimestamp: null
+  name: unit-testing-notebook-instance-lifecycle-config
+spec:
+  notebookInstanceLifecycleConfigName: unit-testing-notebook-instance-lifecycle-config
+  onCreate:
+  - content: ZWNobyAiRW50ZXJpbmcgb25DcmVhdGUi
+  onStart:
+  - content: ZWNobyAiRW50ZXJpbmcgb25TdGFydCI=
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:notebook-instance-lifecycle-config/unit-testing-notebook-instance-lifecycle-config
+    ownerAccountID: ""
+  conditions:
+  - status: "True"
+    type: ACK.ResourceSynced
+  creationTime: "0001-01-01T00:00:00Z"

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/readone/observed/conditions_clear_on_success.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/readone/observed/conditions_clear_on_success.yaml
@@ -1,0 +1,20 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: NotebookInstanceLifecycleConfig
+metadata:
+  creationTimestamp: null
+  name: unit-testing-notebook-instance-lifecycle-config
+spec:
+  notebookInstanceLifecycleConfigName: unit-testing-notebook-instance-lifecycle-config
+  onCreate:
+  - content: ZWNobyAiRW50ZXJpbmcgb25DcmVhdGUi
+  onStart:
+  - content: ZWNobyAiRW50ZXJpbmcgb25TdGFydCI=
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:notebook-instance-lifecycle-config/unit-testing-notebook-instance-lifecycle-config
+    ownerAccountID: ""
+  conditions:
+  - status: "False"
+    type: ACK.Terminal
+  creationTime: "0001-01-01T00:00:00Z"
+  lastModifiedTime: "0001-01-01T00:00:00Z"

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/readone/observed/creating_after_describe.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/readone/observed/creating_after_describe.yaml
@@ -1,0 +1,20 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: NotebookInstanceLifecycleConfig
+metadata:
+  creationTimestamp: null
+  name: unit-testing-notebook-instance-lifecycle-config
+spec:
+  notebookInstanceLifecycleConfigName: unit-testing-notebook-instance-lifecycle-config
+  onCreate:
+  - content: ZWNobyAiRW50ZXJpbmcgb25DcmVhdGUi
+  onStart:
+  - content: ZWNobyAiRW50ZXJpbmcgb25TdGFydCI=
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:notebook-instance-lifecycle-config/unit-testing-notebook-instance-lifecycle-config
+    ownerAccountID: ""
+  conditions:
+  - status: "True"
+    type: ACK.ResourceSynced
+  creationTime: "0001-01-01T00:00:00Z"
+  lastModifiedTime: "0001-01-01T00:00:00Z"

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/readone/observed/error_on_describe.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/readone/observed/error_on_describe.yaml
@@ -1,0 +1,22 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: NotebookInstanceLifecycleConfig
+metadata:
+  creationTimestamp: null
+  name: unit-testing-notebook-instance-lifecycle-config
+spec:
+  notebookInstanceLifecycleConfigName: unit-testing-notebook-instance-lifecycle-config
+  onCreate:
+  - content: ZWNobyAiRW50ZXJpbmcgb25DcmVhdGUi
+  onStart:
+  - content: ZWNobyAiRW50ZXJpbmcgb25TdGFydCI=
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:notebook-instance-lifecycle-config/unit-testing-notebook-instance-lifecycle-config
+    ownerAccountID: ""
+  conditions:
+  - status: "True"
+    type: ACK.ResourceSynced
+  - message: "ServiceUnavailable: Server is down\n\tstatus code: 0, request id: "
+    status: "True"
+    type: ACK.Recoverable
+  creationTime: null

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/update/desired/update_common.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/update/desired/update_common.yaml
@@ -1,0 +1,10 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: NotebookInstanceLifecycleConfig
+metadata:
+  name: unit-testing-notebook-instance-lifecycle-config
+spec:
+  notebookInstanceLifecycleConfigName: unit-testing-notebook-instance-lifecycle-config
+  onStart:
+    - content: cGlwIGluc3RhbGwgc2l4
+  onCreate:
+    - content: dGVzdGluZyB1cGRhdGU=

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/update/observed/error_on_update.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/update/observed/error_on_update.yaml
@@ -1,0 +1,22 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: NotebookInstanceLifecycleConfig
+metadata:
+  creationTimestamp: null
+  name: unit-testing-notebook-instance-lifecycle-config
+spec:
+  notebookInstanceLifecycleConfigName: unit-testing-notebook-instance-lifecycle-config
+  onCreate:
+  - content: ZWNobyAiRW50ZXJpbmcgb25DcmVhdGUi
+  onStart:
+  - content: ZWNobyAiRW50ZXJpbmcgb25TdGFydCI=
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:notebook-instance-lifecycle-config/unit-testing-notebook-instance-lifecycle-config
+    ownerAccountID: ""
+  conditions:
+  - status: "True"
+    type: ACK.ResourceSynced
+  - message: "ServiceUnavailable: Server is down\n\tstatus code: 0, request id: "
+    status: "True"
+    type: ACK.Recoverable
+  creationTime: null

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/update/observed/update_attempted_success.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/v1alpha1/update/observed/update_attempted_success.yaml
@@ -1,0 +1,18 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: NotebookInstanceLifecycleConfig
+metadata:
+  creationTimestamp: null
+  name: unit-testing-notebook-instance-lifecycle-config
+spec:
+  notebookInstanceLifecycleConfigName: unit-testing-notebook-instance-lifecycle-config
+  onCreate:
+  - content: dGVzdGluZyB1cGRhdGU=
+  onStart:
+  - content: cGlwIGluc3RhbGwgc2l4
+status:
+  ackResourceMetadata:
+    ownerAccountID: ""
+  conditions:
+  - message: NotebookInstanceLifecycleConfig is updating.
+    status: "True"
+    type: ACK.Recoverable


### PR DESCRIPTION
Description of changes:
Sdk.go 93.1% coverage
Custom code coverage >90%

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
