### PR TITLE
Use available instance type for notebook-instance tests selected by region

### DIFF
--- a/test/e2e/replacement_values.py
+++ b/test/e2e/replacement_values.py
@@ -176,6 +176,10 @@ TRAINING_JOB_INSTANCE_TYPES = {
     "eu-north-1": "ml.m5.xlarge",
 }
 
+NOTEBOOK_INSTANCE_INSTANCE_TYPES = {
+    "eu-north-1": "ml.t3.medium",
+}
+
 REPLACEMENT_VALUES = {
     "SAGEMAKER_DATA_BUCKET": get_bootstrap_resources().DataBucketName,
     "XGBOOST_IMAGE_URI": f"{XGBOOST_IMAGE_URIS[get_region()]}/sagemaker-xgboost:1.0-1-cpu-py3",
@@ -185,6 +189,11 @@ REPLACEMENT_VALUES = {
     "SAGEMAKER_EXECUTION_ROLE_ARN": get_bootstrap_resources().ExecutionRoleARN,
     "MODEL_MONITOR_ANALYZER_IMAGE_URI": f"{MODEL_MONITOR_IMAGE_URIS[get_region()]}/sagemaker-model-monitor-analyzer",
     "CLARIFY_IMAGE_URI": f"{CLARIFY_IMAGE_URIS[get_region()]}/sagemaker-clarify-processing:1.0",
-    "ENDPOINT_INSTANCE_TYPE": ENDPOINT_INSTANCE_TYPES.get(get_region(), 'ml.c5.large'),
-    "TRAINING_JOB_INSTANCE_TYPE": TRAINING_JOB_INSTANCE_TYPES.get(get_region(), 'ml.m4.xlarge')
+    "ENDPOINT_INSTANCE_TYPE": ENDPOINT_INSTANCE_TYPES.get(get_region(), "ml.c5.large"),
+    "TRAINING_JOB_INSTANCE_TYPE": TRAINING_JOB_INSTANCE_TYPES.get(
+        get_region(), "ml.m4.xlarge"
+    ),
+    "NOTEBOOK_INSTANCE_INSTANCE_TYPES": NOTEBOOK_INSTANCE_INSTANCE_TYPES.get(
+        get_region(), "ml.t2.medium"
+    ),
 }

--- a/test/e2e/resources/notebook_instance.yaml
+++ b/test/e2e/resources/notebook_instance.yaml
@@ -3,7 +3,7 @@ kind: NotebookInstance
 metadata:
   name: $NOTEBOOK_INSTANCE_NAME
 spec:
-  instanceType: ml.t2.medium
+  instanceType: $NOTEBOOK_INSTANCE_INSTANCE_TYPES
   notebookInstanceName: $NOTEBOOK_INSTANCE_NAME
   roleARN: $SAGEMAKER_EXECUTION_ROLE_ARN
   volumeSizeInGB: 6


### PR DESCRIPTION
- Use different instance type for `eu-north-1` for notebook_instance test
  - This is because the default instance type is not available on `eu-north-1`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
