### PR TITLE
Release artifacts for release v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Take note of IAM_ROLE_ARN_FOR_IRSA printed in the previous step; you will pass t
 ```sh
 export HELM_EXPERIMENTAL_OCI=1
 export SERVICE=sagemaker
-export RELEASE_VERSION=v0.1.0
+export RELEASE_VERSION=v0.2.0
 export CHART_EXPORT_PATH=/tmp/chart
 export CHART_REF=$SERVICE-chart
 export CHART_REPO=public.ecr.aws/aws-controllers-k8s/$CHART_REF
@@ -225,7 +225,7 @@ Jump to Section 4.0 if you only wish to install SageMaker controller
 ```sh
 export HELM_EXPERIMENTAL_OCI=1
 export SERVICE=applicationautoscaling
-export RELEASE_VERSION=v0.1.1
+export RELEASE_VERSION=v0.2.0
 export CHART_EXPORT_PATH=/tmp/chart
 export CHART_REF=$SERVICE-chart
 export CHART_REPO=public.ecr.aws/aws-controllers-k8s/$CHART_REF

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2021-10-08T20:19:54Z"
+  build_date: "2021-10-21T19:55:26Z"
   build_hash: 1eaee0ea592ad5752cb9d403e2c13e9a7bdb8d33
   go_version: go1.17.1
   version: v0.15.1

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: sagemaker-chart
 description: A Helm chart for the ACK service controller for Amazon SageMaker (SageMaker)
-version: v0.1.0
-appVersion: v0.1.0
+version: v0.2.0
+appVersion: v0.2.0
 home: https://github.com/aws-controllers-k8s/sagemaker-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/sagemaker-controller
-  tag: v0.1.0
+  tag: v0.2.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/pkg/resource/notebook_instance/hooks.go
+++ b/pkg/resource/notebook_instance/hooks.go
@@ -20,7 +20,7 @@ var (
 		svcsdk.NotebookInstanceStatusStopping,
 	}
 
-	resourceName = GroupKind.Kind
+	resourceName             = GroupKind.Kind
 	requeueWaitWhileDeleting = ackrequeue.NeededAfter(
 		errors.New(resourceName+" is deleting."),
 		ackrequeue.DefaultRequeueAfterDuration,


### PR DESCRIPTION
Release Notes Draft:
- Unit tests for all resources currently included in [pkg/resource](https://github.com/aws-controllers-k8s/sagemaker-controller/tree/main/pkg/resource)
- Helm image is updated to be Helm 3.7 compatible #58 
  -  ⚠️ **Breaking Change** Helm versions < `3.7` are no longer compatible
- Update ACK Runtime from `0.14.0` to `0.15.1` #62 
  - ⚠️ **Breaking Change** `aws-account-id` can no longer be set and has been removed from the charts.
  - Please refer to https://github.com/aws-controllers-k8s/runtime/releases for a detailed list of changes 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.