### PR TITLE
Remove YamlEqual method to remove duplicate work and bash commands

### DIFF
--- a/pkg/resource/data_quality_job_definition/manager_test_suite_test.go
+++ b/pkg/resource/data_quality_job_definition/manager_test_suite_test.go
@@ -17,19 +17,19 @@ import (
 	"errors"
 	"fmt"
 
+	"path/filepath"
+	"testing"
+
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
-	"path/filepath"
 	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
 )
 
 // provideResourceManagerWithMockSDKAPI accepts MockSageMakerAPI and returns pointer to resourceManager
@@ -127,13 +127,4 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	}
 
 	return statusMatch && specMatch
-}
-
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
 }

--- a/pkg/resource/endpoint/manager_test_suite_test.go
+++ b/pkg/resource/endpoint/manager_test_suite_test.go
@@ -17,6 +17,9 @@ import (
 	"errors"
 	"fmt"
 
+	"path/filepath"
+	"testing"
+
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
@@ -24,13 +27,10 @@ import (
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
-	"path/filepath"
 	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
 )
 
 // provideResourceManagerWithMockSDKAPI accepts MockSageMakerAPI and returns pointer to resourceManager
@@ -117,20 +117,23 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 		cmpopts.IgnoreFields(svcapitypes.DeployedImage{}, "ResolutionTime"),
 	}
 
-	if cmp.Equal(ac.ko.Status, bc.ko.Status, opts...) {
-		return true
+	var specMatch = false
+	if cmp.Equal(ac.ko.Spec, bc.ko.Spec, opts...) {
+		specMatch = true
 	} else {
-		fmt.Printf("Difference (-expected +actual):\n\n")
-		fmt.Println(cmp.Diff(ac.ko.Status, bc.ko.Status, opts...))
-		return false
+		fmt.Printf("Difference ko.Spec (-expected +actual):\n\n")
+		fmt.Println(cmp.Diff(ac.ko.Spec, bc.ko.Spec, opts...))
+		specMatch = false
 	}
-}
 
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
+	var statusMatch = false
+	if cmp.Equal(ac.ko.Status, bc.ko.Status, opts...) {
+		statusMatch = true
+	} else {
+		fmt.Printf("Difference ko.Status (-expected +actual):\n\n")
+		fmt.Println(cmp.Diff(ac.ko.Status, bc.ko.Status, opts...))
+		statusMatch = false
+	}
+
+	return statusMatch && specMatch
 }

--- a/pkg/resource/endpoint_config/manager_test_suite_test.go
+++ b/pkg/resource/endpoint_config/manager_test_suite_test.go
@@ -17,19 +17,19 @@ import (
 	"errors"
 	"fmt"
 
+	"path/filepath"
+	"testing"
+
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
-	"path/filepath"
 	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
 )
 
 // provideResourceManagerWithMockSDKAPI accepts MockSageMakerAPI and returns pointer to resourceManager
@@ -121,13 +121,4 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	}
 
 	return statusMatch && specMatch
-}
-
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
 }

--- a/pkg/resource/feature_group/manager_test_suite_test.go
+++ b/pkg/resource/feature_group/manager_test_suite_test.go
@@ -17,19 +17,19 @@ import (
 	"errors"
 	"fmt"
 
+	"path/filepath"
+	"testing"
+
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
-	"path/filepath"
 	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
 )
 
 // provideResourceManagerWithMockSDKAPI accepts MockSageMakerAPI and returns pointer to resourceManager
@@ -108,20 +108,23 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	// Ignore LastTransitionTime since it gets updated each run.
 	opts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.IgnoreFields(ackv1alpha1.Condition{}, "LastTransitionTime")}
 
-	if cmp.Equal(ac.ko.Status, bc.ko.Status, opts...) {
-		return true
+	var specMatch = false
+	if cmp.Equal(ac.ko.Spec, bc.ko.Spec, opts...) {
+		specMatch = true
 	} else {
-		fmt.Printf("Difference (-expected +actual):\n\n")
-		fmt.Println(cmp.Diff(ac.ko.Status, bc.ko.Status, opts...))
-		return false
+		fmt.Printf("Difference ko.Spec (-expected +actual):\n\n")
+		fmt.Println(cmp.Diff(ac.ko.Spec, bc.ko.Spec, opts...))
+		specMatch = false
 	}
-}
 
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
+	var statusMatch = false
+	if cmp.Equal(ac.ko.Status, bc.ko.Status, opts...) {
+		statusMatch = true
+	} else {
+		fmt.Printf("Difference ko.Status (-expected +actual):\n\n")
+		fmt.Println(cmp.Diff(ac.ko.Status, bc.ko.Status, opts...))
+		statusMatch = false
+	}
+
+	return statusMatch && specMatch
 }

--- a/pkg/resource/hyper_parameter_tuning_job/manager_test_suite_test.go
+++ b/pkg/resource/hyper_parameter_tuning_job/manager_test_suite_test.go
@@ -28,7 +28,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
@@ -128,13 +127,4 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	}
 
 	return statusMatch && specMatch
-}
-
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
 }

--- a/pkg/resource/model/manager_test_suite_test.go
+++ b/pkg/resource/model/manager_test_suite_test.go
@@ -17,19 +17,19 @@ import (
 	"errors"
 	"fmt"
 
+	"path/filepath"
+	"testing"
+
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
-	"path/filepath"
 	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
 )
 
 // provideResourceManagerWithMockSDKAPI accepts MockSageMakerAPI and returns pointer to resourceManager
@@ -121,13 +121,4 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	}
 
 	return statusMatch && specMatch
-}
-
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
 }

--- a/pkg/resource/model_bias_job_definition/manager_test_suite_test.go
+++ b/pkg/resource/model_bias_job_definition/manager_test_suite_test.go
@@ -17,19 +17,19 @@ import (
 	"errors"
 	"fmt"
 
+	"path/filepath"
+	"testing"
+
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
-	"path/filepath"
 	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
 )
 
 // provideResourceManagerWithMockSDKAPI accepts MockSageMakerAPI and returns pointer to resourceManager
@@ -121,13 +121,4 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	}
 
 	return statusMatch && specMatch
-}
-
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
 }

--- a/pkg/resource/model_explainability_job_definition/manager_test_suite_test.go
+++ b/pkg/resource/model_explainability_job_definition/manager_test_suite_test.go
@@ -17,19 +17,19 @@ import (
 	"errors"
 	"fmt"
 
+	"path/filepath"
+	"testing"
+
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
-	"path/filepath"
 	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
 )
 
 // provideResourceManagerWithMockSDKAPI accepts MockSageMakerAPI and returns pointer to resourceManager
@@ -121,13 +121,4 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	}
 
 	return statusMatch && specMatch
-}
-
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
 }

--- a/pkg/resource/model_package/manager_test_suite_test.go
+++ b/pkg/resource/model_package/manager_test_suite_test.go
@@ -17,6 +17,9 @@ import (
 	"errors"
 	"fmt"
 
+	"path/filepath"
+	"testing"
+
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
@@ -24,13 +27,10 @@ import (
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
-	"path/filepath"
 	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
 )
 
 // provideResourceManagerWithMockSDKAPI accepts MockSageMakerAPI and returns pointer to resourceManager
@@ -128,13 +128,4 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	}
 
 	return statusMatch && specMatch
-}
-
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
 }

--- a/pkg/resource/model_package_group/manager_test_suite_test.go
+++ b/pkg/resource/model_package_group/manager_test_suite_test.go
@@ -17,19 +17,19 @@ import (
 	"errors"
 	"fmt"
 
+	"path/filepath"
+	"testing"
+
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
-	"path/filepath"
 	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
 )
 
 // provideResourceManagerWithMockSDKAPI accepts MockSageMakerAPI and returns pointer to resourceManager
@@ -121,13 +121,4 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	}
 
 	return statusMatch && specMatch
-}
-
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
 }

--- a/pkg/resource/model_quality_job_definition/manager_test_suite_test.go
+++ b/pkg/resource/model_quality_job_definition/manager_test_suite_test.go
@@ -17,19 +17,19 @@ import (
 	"errors"
 	"fmt"
 
+	"path/filepath"
+	"testing"
+
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackmetrics "github.com/aws-controllers-k8s/runtime/pkg/metrics"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
-	"path/filepath"
 	ctrlrtzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
 )
 
 // provideResourceManagerWithMockSDKAPI accepts MockSageMakerAPI and returns pointer to resourceManager
@@ -102,20 +102,23 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	// Ignore LastTransitionTime since it gets updated each run.
 	opts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.IgnoreFields(ackv1alpha1.Condition{}, "LastTransitionTime")}
 
-	if cmp.Equal(ac.ko.Status, bc.ko.Status, opts...) {
-		return true
+	var specMatch = false
+	if cmp.Equal(ac.ko.Spec, bc.ko.Spec, opts...) {
+		specMatch = true
 	} else {
-		fmt.Printf("Difference (-expected +actual):\n\n")
-		fmt.Println(cmp.Diff(ac.ko.Status, bc.ko.Status, opts...))
-		return false
+		fmt.Printf("Difference ko.Spec (-expected +actual):\n\n")
+		fmt.Println(cmp.Diff(ac.ko.Spec, bc.ko.Spec, opts...))
+		specMatch = false
 	}
-}
 
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
+	var statusMatch = false
+	if cmp.Equal(ac.ko.Status, bc.ko.Status, opts...) {
+		statusMatch = true
+	} else {
+		fmt.Printf("Difference ko.Status (-expected +actual):\n\n")
+		fmt.Println(cmp.Diff(ac.ko.Status, bc.ko.Status, opts...))
+		statusMatch = false
+	}
+
+	return statusMatch && specMatch
 }

--- a/pkg/resource/monitoring_schedule/manager_test_suite_test.go
+++ b/pkg/resource/monitoring_schedule/manager_test_suite_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
@@ -129,13 +128,4 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	}
 
 	return statusMatch && specMatch
-}
-
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
 }

--- a/pkg/resource/notebook_instance/manager_test_suite_test.go
+++ b/pkg/resource/notebook_instance/manager_test_suite_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
@@ -118,20 +117,23 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	// Ignore LastTransitionTime since it gets updated each run.
 	opts := []cmp.Option{cmpopts.EquateEmpty(), cmpopts.IgnoreFields(ackv1alpha1.Condition{}, "LastTransitionTime")}
 
-	if cmp.Equal(ac.ko.Status, bc.ko.Status, opts...) {
-		return true
+	var specMatch = false
+	if cmp.Equal(ac.ko.Spec, bc.ko.Spec, opts...) {
+		specMatch = true
 	} else {
-		fmt.Printf("Difference (-expected +actual):\n\n")
-		fmt.Println(cmp.Diff(ac.ko.Status, bc.ko.Status, opts...))
-		return false
+		fmt.Printf("Difference ko.Spec (-expected +actual):\n\n")
+		fmt.Println(cmp.Diff(ac.ko.Spec, bc.ko.Spec, opts...))
+		specMatch = false
 	}
-}
 
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
+	var statusMatch = false
+	if cmp.Equal(ac.ko.Status, bc.ko.Status, opts...) {
+		statusMatch = true
+	} else {
+		fmt.Printf("Difference ko.Status (-expected +actual):\n\n")
+		fmt.Println(cmp.Diff(ac.ko.Status, bc.ko.Status, opts...))
+		statusMatch = false
+	}
+
+	return statusMatch && specMatch
 }

--- a/pkg/resource/notebook_instance_lifecycle_config/manager_test_suite_test.go
+++ b/pkg/resource/notebook_instance_lifecycle_config/manager_test_suite_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
@@ -125,13 +124,4 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	}
 
 	return statusMatch && specMatch
-}
-
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
 }

--- a/pkg/resource/processing_job/manager_test_suite_test.go
+++ b/pkg/resource/processing_job/manager_test_suite_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
@@ -122,13 +121,4 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	}
 
 	return statusMatch && specMatch
-}
-
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
 }

--- a/pkg/resource/training_job/manager_test_suite_test.go
+++ b/pkg/resource/training_job/manager_test_suite_test.go
@@ -28,7 +28,6 @@ import (
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
 
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
@@ -127,13 +126,4 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	}
 
 	return statusMatch && specMatch
-}
-
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
 }

--- a/pkg/resource/transform_job/manager_test_suite_test.go
+++ b/pkg/resource/transform_job/manager_test_suite_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/aws-controllers-k8s/sagemaker-controller/pkg/testutil"
 	mocksvcsdkapi "github.com/aws-controllers-k8s/sagemaker-controller/test/mocks/aws-sdk-go/sagemaker"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap/zapcore"
@@ -122,13 +121,4 @@ func (d *testRunnerDelegate) Equal(a acktypes.AWSResource, b acktypes.AWSResourc
 	}
 
 	return statusMatch && specMatch
-}
-
-// Checks to see if the given yaml file, with name stored as expectation,
-// matches the yaml marshal of the AWSResource stored as actual.
-func (d *testRunnerDelegate) YamlEqual(expectation string, actual acktypes.AWSResource) bool {
-	// Build a tmp file for the actual yaml.
-	actualResource := actual.(*resource)
-	actualYamlByteArray, _ := yaml.Marshal(actualResource.ko)
-	return testutil.IsYamlEqual(&expectation, &actualYamlByteArray)
 }

--- a/pkg/testutil/test_suite_runner.go
+++ b/pkg/testutil/test_suite_runner.go
@@ -55,7 +55,6 @@ type expectContext struct {
 type TestRunnerDelegate interface {
 	ResourceDescriptor() acktypes.AWSResourceDescriptor
 	Equal(desired acktypes.AWSResource, latest acktypes.AWSResource) bool // remove it when ResourceDescriptor.Delta() is available
-	YamlEqual(expected string, actual acktypes.AWSResource) bool          // new
 	ResourceManager(*mocksvcsdkapi.SageMakerAPI) acktypes.AWSResourceManager
 	EmptyServiceAPIOutput(apiName string) (interface{}, error)
 	GoTestRunner() *testing.T
@@ -150,10 +149,7 @@ func (runner *TestSuiteRunner) assertExpectations(assert *assert.Assertions, exp
 			}
 		}
 
-		// Check that the yaml files are equivalent.
-		// This makes it easier to make changes to unit test cases.
-		assert.True(runner.Delegate.YamlEqual(expectation.LatestState, actual))
-		// Delta only contains `Spec` differences. Thus, we need Delegate.Equal to compare `Status`.
+		// Delegate.Equal to compare 'Spec' and 'Status' of the resource
 		assert.True(runner.Delegate.Equal(expectedLatest, actual))
 	}
 

--- a/pkg/testutil/util.go
+++ b/pkg/testutil/util.go
@@ -18,19 +18,11 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"os/exec"
 	"path"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/ghodss/yaml"
-)
-
-var (
-	TestDataDirectory      = "testdata"
-	DefaultTimestamp       = "0001-01-01T00:00:00Z"
-	ReplaceTimestampRegExp = "s/\"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\"/\"" + DefaultTimestamp + "\"/"
 )
 
 // LoadFromFixture fills an empty pointer variable with the
@@ -63,82 +55,4 @@ func LoadFromFixture(
 func CreateAWSError(awsError ServiceAPIError) awserr.RequestFailure {
 	error := awserr.New(awsError.Code, awsError.Message, nil)
 	return awserr.NewRequestFailure(error, 0, "")
-}
-
-// Checks to see if the contents of a given yaml file, with name stored
-// in expectation, matches the given actualYamlByteArray.
-func IsYamlEqual(expectation *string, actualYamlByteArray *[]byte) bool {
-	// Get the file name of the expected yaml.
-	expectedYamlFileName := TestDataDirectory + "/" + *expectation
-
-	// Build a tmp file for the actual yaml.
-	actualYamlFileName := buildTmpFile("actualYaml", *actualYamlByteArray)
-	defer os.Remove(actualYamlFileName)
-	if "" == actualYamlFileName {
-		fmt.Printf("Could not create temporary actual file.\n")
-		return false
-	}
-
-	// Replace Timestamps that would show up as different.
-	_, err := exec.Command("sed", "-r", "-i.tmp", ReplaceTimestampRegExp, actualYamlFileName).Output()
-	if isExecCommandError(err) {
-		return false
-	}
-
-	// Remove tmp files used as backup https://riptutorial.com/sed/topic/9436/bsd-macos-sed-vs--gnu-sed-vs--the-posix-sed-specification
-	// -i inplace-editing is not consistent on both GNU and non-GNU sed when not specifiying a backup file.
-	actualYamlFileNameTmp := actualYamlFileName + ".tmp"
-	defer os.Remove(actualYamlFileNameTmp)
-
-	output, err := exec.Command("diff", "-c", expectedYamlFileName, actualYamlFileName).Output()
-	if isExecCommandError(err) {
-		return false
-	}
-
-	if len(output) > 0 {
-		actualOutput, err := exec.Command("cat", actualYamlFileName).Output()
-		if isExecCommandError(err) {
-			return false
-		}
-		fmt.Printf("\nExpected Yaml File Name: " + expectedYamlFileName + "\n")
-		fmt.Printf("\nActual Output Yaml:\n" + string(actualOutput) + "\n")
-		fmt.Printf("Diff From Expected:\n" + string(output) + "\n")
-		return false
-	}
-	return true
-}
-
-func buildTmpFile(fileNameBase string, contents []byte) string {
-	newTmpFile, err := ioutil.TempFile(TestDataDirectory, fileNameBase)
-	if err != nil {
-		fmt.Println(err)
-		return ""
-	}
-	if _, err := newTmpFile.Write(contents); err != nil {
-		fmt.Println(err)
-		return ""
-	}
-	if err := newTmpFile.Close(); err != nil {
-		fmt.Println(err)
-		return ""
-	}
-	return newTmpFile.Name()
-}
-
-// isExecCommandError returns true if an error
-// that is not an ExitError is found.
-func isExecCommandError(err error) bool {
-	if err == nil {
-		return false
-	}
-	switch err.(type) {
-	case *exec.ExitError:
-		// ExitError is expected.
-		return false
-	default:
-		// Couldn't run diff.
-		fmt.Printf("Exec Command Error: ")
-		fmt.Println(err)
-		return true
-	}
 }


### PR DESCRIPTION
Description of changes:
Remove yaml equality check from `util.go` as it is not necessary if we check the spec like we check the status. This will also remove the usage of bash commands such as `sed`, `diff`, and `cat`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
