### PR TITLE
updating olm config to link to openshift preinstallation steps

### DIFF
--- a/olm/olmconfig.yaml
+++ b/olm/olmconfig.yaml
@@ -25,7 +25,13 @@ description: |-
 
   This controller is a component of the [AWS Controller for
   Kubernetes](https://github.com/aws/aws-controllers-k8s)project. This project
-  is currently in **developer preview**. 
+  is currently in **developer preview**.
+
+
+  **Pre-Installation Steps**
+
+
+  Please follow the following link: [Red Hat OpenShift](https://aws-controllers-k8s.github.io/community/docs/user-docs/openshift/)
 samples:
 - kind: DataQualityJobDefinition
   spec: '{}'
@@ -52,8 +58,8 @@ samples:
 - kind: TransformJob
   spec: '{}'
 maintainers:
-- name: "Your Team Name"
-  email: "your-team@example.com"
+- name: "sagemaker maintainer team"
+  email: "ack-maintainers@amazon.com"
 links:
 - name: Amazon SageMaker Developer Resources
   url: https://aws.amazon.com/sagemaker/developer-resources/


### PR DESCRIPTION
Issue #, if available:
N/A
Description of changes:
Updating the `olmconfig.yaml` to have a link to the preinstallation steps for OpenShift, as well as adding in the maintainers name/email. This information is used when generating the bundle.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Adam D. Cornett <adc@redhat.com>