### PR TITLE
Add unit tests that invoke late initialize

### DIFF
--- a/pkg/resource/data_quality_job_definition/testdata/test_suite.yaml
+++ b/pkg/resource/data_quality_job_definition/testdata/test_suite.yaml
@@ -71,6 +71,16 @@ tests:
       invoke: ReadOne
       expect:
         latest_state: "v1alpha1/create/observed/success_after_create.yaml"
+    - name: "ReadOne=LateInitialize"
+      description: "Testing late initialize after created, should expect no diff since there is nothing to late initialize"
+      given:
+        desired_state: "v1alpha1/create/observed/success_after_create.yaml"
+        svc_api:
+          - operation: DescribeDataQualityJobDefinitionWithContext
+            output_fixture: "sdkapi/describe/success_describe.json"
+      invoke: LateInitialize
+      expect:
+        latest_state: "v1alpha1/create/observed/success_after_create.yaml"
     - name: "ReadOne=SuccessClearsConditions"
       description: Testing a successful reconciliation clears conditions if terminal/recoverable condition were already set to true
       given:

--- a/pkg/resource/endpoint/testdata/test_suite.yaml
+++ b/pkg/resource/endpoint/testdata/test_suite.yaml
@@ -71,6 +71,16 @@ tests:
         invoke: ReadOne
         expect:
           latest_state: "v1alpha1/readone/observed/creating_after_describe.yaml"
+      - name: "ReadOne=LateInitialize"
+        description: "Testing late initialize after created, should expect no diff since there is nothing to late initialize"
+        given:
+          desired_state: "v1alpha1/readone/observed/creating_after_describe.yaml"
+          svc_api:
+            - operation: DescribeEndpointWithContext
+              output_fixture: "sdkapi/describe/creating_after_create.json"
+        invoke: LateInitialize
+        expect:
+          latest_state: "v1alpha1/readone/observed/creating_after_describe.yaml"
       - name: "ReadOne=InService"
         description: "Testing readOne when InService, resource synced should be true."
         given: 

--- a/pkg/resource/endpoint_config/testdata/test_suite.yaml
+++ b/pkg/resource/endpoint_config/testdata/test_suite.yaml
@@ -70,6 +70,16 @@
         invoke: ReadOne
         expect:
           latest_state: "v1alpha1/readone/desired/right_after_create.yaml"
+      - name: "ReadOne=LateInitialize"
+        description: "Testing late initialize after created, should expect no diff since there is nothing to late initialize"
+        given:
+          desired_state: "v1alpha1/readone/desired/right_after_create.yaml"
+          svc_api:
+            - operation: DescribeEndpointConfigWithContext
+              output_fixture: "sdkapi/describe/success_describe.json"
+        invoke: LateInitialize
+        expect:
+          latest_state: "v1alpha1/readone/desired/right_after_create.yaml"
       - name: "ReadOne=SuccessClearsConditions"
         description: "Testing a successful reconciliation clears conditions if terminal/recoverable condition were already set to true"
         given:

--- a/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_late_initialize.yaml
+++ b/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_late_initialize.yaml
@@ -23,8 +23,7 @@ status:
     arn: arn:aws:sagemaker:us-west-2:123456789012:feature-group/unit-testing-feature-group
     ownerAccountID: ""
   conditions:
-  - lastTransitionTime: null
-    message: FeatureGroup is in Creating status.
+  - message: FeatureGroup is in Creating status.
     status: "False"
     type: ACK.ResourceSynced
   - lastTransitionTime: "0001-01-01T00:00:00Z"

--- a/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_late_initialize.yaml
+++ b/pkg/resource/feature_group/testdata/feature_group/v1alpha1/fg_late_initialize.yaml
@@ -1,0 +1,35 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: FeatureGroup
+metadata:
+  creationTimestamp: null
+  name: unit-testing-feature-group
+spec:
+  eventTimeFeatureName: EventTime
+  featureDefinitions:
+  - featureName: TransactionID
+    featureType: Integral
+  - featureName: EventTime
+    featureType: Fractional
+  featureGroupName: unit-testing-feature-group
+  offlineStoreConfig:
+    disableGlueTableCreation: false
+    s3StorageConfig:
+      resolvedOutputS3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data/123456789012/sagemaker/us-west-2/offline-store/unit-testing-feature-group-1627432365/data
+      s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/feature-group-data
+  recordIdentifierFeatureName: TransactionID
+  roleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:feature-group/unit-testing-feature-group
+    ownerAccountID: ""
+  conditions:
+  - lastTransitionTime: null
+    message: FeatureGroup is in Creating status.
+    status: "False"
+    type: ACK.ResourceSynced
+  - lastTransitionTime: "0001-01-01T00:00:00Z"
+    message: Late initialization successful
+    reason: Late initialization successful
+    status: "True"
+    type: ACK.LateInitialized
+  featureGroupStatus: Creating

--- a/pkg/resource/feature_group/testdata/test_suite.yaml
+++ b/pkg/resource/feature_group/testdata/test_suite.yaml
@@ -41,6 +41,17 @@ tests:
         expect:
           latest_state: "feature_group/v1alpha1/fg_creating_state.yaml"
           error: nil
+      - name: "ReadOne=LateInitialize"
+        description: "Verifies that LateInitialize condition is set as successful"
+        given:
+          desired_state: "feature_group/v1alpha1/fg_creating_state.yaml"
+          svc_api:
+            - operation: DescribeFeatureGroupWithContext
+              output_fixture: "feature_group/read_one/fg_creating.json"
+        invoke: LateInitialize
+        expect:
+          latest_state: "feature_group/v1alpha1/fg_late_initialize.yaml"
+          error: nil
       - name: "ReadOne=CreateFailed"
         description: "A feature group in the creating state which enters the create failed state will have the terminal condition set to True."
         given:

--- a/pkg/resource/hyper_parameter_tuning_job/testdata/test_suite.yaml
+++ b/pkg/resource/hyper_parameter_tuning_job/testdata/test_suite.yaml
@@ -103,6 +103,16 @@
         invoke: ReadOne
         expect:
           latest_state: "v1alpha1/readone/observed/inprogress.yaml"
+      - name: "ReadOne=LateInitialize"
+        description: "Verifies that LateInitialize condition is set as successful"
+        given:
+          desired_state: "v1alpha1/readone/observed/inprogress.yaml"
+          svc_api:
+            - operation: DescribeHyperParameterTuningJobWithContext
+              output_fixture: "sdkapi/describe/inprogress_describe.json"
+        invoke: LateInitialize
+        expect:
+          latest_state: "v1alpha1/readone/observed/late_initialize.yaml"
       - name: "ReadOne=AfterCompletion"
         description: "Testing readOne after HyperParameter tuning job completes, the status should have ARN."
         given:

--- a/pkg/resource/hyper_parameter_tuning_job/testdata/v1alpha1/readone/observed/late_initialize.yaml
+++ b/pkg/resource/hyper_parameter_tuning_job/testdata/v1alpha1/readone/observed/late_initialize.yaml
@@ -119,8 +119,7 @@ status:
     arn: arn:aws:sagemaker:us-west-2:123456789012:hyper-parameter-tuning-job/unit-testing-hpo-job
     ownerAccountID: ""
   conditions:
-  - lastTransitionTime: null
-    message: HyperParameterTuningJob is in InProgress status.
+  - message: HyperParameterTuningJob is in InProgress status.
     status: "False"
     type: ACK.ResourceSynced
   - lastTransitionTime: "0001-01-01T00:00:00Z"

--- a/pkg/resource/hyper_parameter_tuning_job/testdata/v1alpha1/readone/observed/late_initialize.yaml
+++ b/pkg/resource/hyper_parameter_tuning_job/testdata/v1alpha1/readone/observed/late_initialize.yaml
@@ -1,0 +1,131 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: HyperParameterTuningJob
+metadata:
+  creationTimestamp: null
+  name: unit-testing-hyper-parameter-tuning-job
+spec:
+  hyperParameterTuningJobConfig:
+    hyperParameterTuningJobObjective:
+      metricName: validation:error
+      type_: Minimize
+    parameterRanges:
+      categoricalParameterRanges:
+      - name: category
+        values:
+        - test
+      continuousParameterRanges:
+      - maxValue: "5"
+        minValue: "0"
+        name: gamma
+        scalingType: Linear
+      integerParameterRanges:
+      - maxValue: "20"
+        minValue: "10"
+        name: num_round
+        scalingType: Linear
+    resourceLimits:
+      maxNumberOfTrainingJobs: 2
+      maxParallelTrainingJobs: 1
+    strategy: Bayesian
+    trainingJobEarlyStoppingType: Auto
+  hyperParameterTuningJobName: unit-testing-hpo-job
+  tags:
+  - key: algorithm
+    value: xgboost
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user
+  trainingJobDefinition:
+    algorithmSpecification:
+      metricDefinitions:
+      - name: train:mae
+        regex: .*\[[0-9]+\].*#011train-mae:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: validation:auc
+        regex: .*\[[0-9]+\].*#011validation-auc:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: train:merror
+        regex: .*\[[0-9]+\].*#011train-merror:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: train:auc
+        regex: .*\[[0-9]+\].*#011train-auc:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: validation:mae
+        regex: .*\[[0-9]+\].*#011validation-mae:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: validation:error
+        regex: .*\[[0-9]+\].*#011validation-error:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: validation:merror
+        regex: .*\[[0-9]+\].*#011validation-merror:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: validation:logloss
+        regex: .*\[[0-9]+\].*#011validation-logloss:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: train:rmse
+        regex: .*\[[0-9]+\].*#011train-rmse:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: train:logloss
+        regex: .*\[[0-9]+\].*#011train-logloss:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: train:mlogloss
+        regex: .*\[[0-9]+\].*#011train-mlogloss:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: validation:rmse
+        regex: .*\[[0-9]+\].*#011validation-rmse:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: validation:ndcg
+        regex: .*\[[0-9]+\].*#011validation-ndcg:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: train:error
+        regex: .*\[[0-9]+\].*#011train-error:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: validation:mlogloss
+        regex: .*\[[0-9]+\].*#011validation-mlogloss:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: train:ndcg
+        regex: .*\[[0-9]+\].*#011train-ndcg:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: train:map
+        regex: .*\[[0-9]+\].*#011train-map:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: validation:map
+        regex: .*\[[0-9]+\].*#011validation-map:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      - name: ObjectiveMetric
+        regex: .*\[[0-9]+\].*#011validation-error:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+      trainingImage: 433757028032.dkr.ecr.us-west-2.amazonaws.com/xgboost:1
+      trainingInputMode: File
+    enableInterContainerTrafficEncryption: false
+    enableManagedSpotTraining: false
+    enableNetworkIsolation: true
+    inputDataConfig:
+    - channelName: train
+      compressionType: None
+      contentType: text/csv
+      dataSource:
+        s3DataSource:
+          s3DataDistributionType: FullyReplicated
+          s3DataType: S3Prefix
+          s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/training/train
+      inputMode: File
+      recordWrapperType: None
+    - channelName: validation
+      compressionType: None
+      contentType: text/csv
+      dataSource:
+        s3DataSource:
+          s3DataDistributionType: FullyReplicated
+          s3DataType: S3Prefix
+          s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/training/validation/
+      inputMode: File
+      recordWrapperType: None
+    outputDataConfig:
+      s3OutputPath: s3://source-data-bucket-592697580195-us-west-2/sagemaker/hpo/output
+    resourceConfig:
+      instanceCount: 1
+      instanceType: ml.m5.large
+      volumeSizeInGB: 25
+    roleARN: arn:aws:iam::123456789012:role/service-role/AmazonSageMaker-ExecutionRole-20210920T111639
+    staticHyperParameters:
+      base_score: "0.5"
+    stoppingCondition:
+      maxRuntimeInSeconds: 3600
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:hyper-parameter-tuning-job/unit-testing-hpo-job
+    ownerAccountID: ""
+  conditions:
+  - lastTransitionTime: null
+    message: HyperParameterTuningJob is in InProgress status.
+    status: "False"
+    type: ACK.ResourceSynced
+  - lastTransitionTime: "0001-01-01T00:00:00Z"
+    message: Late initialization successful
+    reason: Late initialization successful
+    status: "True"
+    type: ACK.LateInitialized
+  hyperParameterTuningJobStatus: InProgress

--- a/pkg/resource/model/testdata/test_suite.yaml
+++ b/pkg/resource/model/testdata/test_suite.yaml
@@ -82,6 +82,16 @@ tests:
         invoke: ReadOne
         expect:
           latest_state: "v1alpha1/readone/observed/created.yaml"
+      - name: "ReadOne=LateInitialize"
+        description: "Verifies that LateInitialize condition is set as successful"
+        given:
+          desired_state: "v1alpha1/readone/observed/created.yaml"
+          svc_api:
+            - operation: DescribeModelWithContext
+              output_fixture: "sdkapi/describe/success_describe.json"
+        invoke: LateInitialize
+        expect:
+          latest_state: "v1alpha1/readone/observed/late_initialize.yaml"
       - name: "ReadOne=AfterCreateVariation2"
         description: "Testing readOne right after create, the status should have ARN."
         given:

--- a/pkg/resource/model/testdata/v1alpha1/readone/observed/late_initialize.yaml
+++ b/pkg/resource/model/testdata/v1alpha1/readone/observed/late_initialize.yaml
@@ -1,0 +1,30 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: Model
+metadata:
+  creationTimestamp: null
+  name: xgboost-model
+spec:
+  containers:
+  - containerHostname: xgboost
+    environment:
+      my_var: my_value
+      my_var2: my_value2
+    image: 246618743249.dkr.ecr.us-west-2.amazonaws.com/sagemaker-xgboost:1.0-1-cpu-py3
+    imageConfig:
+      repositoryAccessMode: Platform
+      repositoryAuthConfig: {}
+    mode: SingleModel
+    modelDataURL: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model/xgboost-mnist-model.tar.gz
+  enableNetworkIsolation: false
+  executionRoleARN: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+  modelName: xgboost-model
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:model/xgboost-model
+    ownerAccountID: ""
+  conditions:
+  - lastTransitionTime: "0001-01-01T00:00:00Z"
+    message: Late initialization successful
+    reason: Late initialization successful
+    status: "True"
+    type: ACK.LateInitialized

--- a/pkg/resource/model_bias_job_definition/testdata/test_suite.yaml
+++ b/pkg/resource/model_bias_job_definition/testdata/test_suite.yaml
@@ -71,6 +71,16 @@ tests:
         invoke: ReadOne
         expect:
           latest_state: "v1alpha1/create/observed/success_after_create.yaml"
+      - name: "ReadOne=LateInitialize"
+        description: "Testing late initialize after created, should expect no diff since there is nothing to late initialize"
+        given:
+          desired_state: "v1alpha1/create/observed/success_after_create.yaml"
+          svc_api:
+            - operation: DescribeModelBiasJobDefinitionWithContext
+              output_fixture: "sdkapi/describe/success_describe.json"
+        invoke: LateInitialize
+        expect:
+          latest_state: "v1alpha1/create/observed/success_after_create.yaml"
       - name: "ReadOne=SuccessClearsConditions"
         description: Testing a successful reconciliation clears conditions if terminal/recoverable condition were already set to true
         given:

--- a/pkg/resource/model_explainability_job_definition/testdata/test_suite.yaml
+++ b/pkg/resource/model_explainability_job_definition/testdata/test_suite.yaml
@@ -71,6 +71,16 @@ tests:
       invoke: ReadOne
       expect:
         latest_state: "v1alpha1/create/observed/success_after_create.yaml"
+    - name: "ReadOne=LateInitialize"
+      description: "Testing late initialize after created, should expect no diff since there is nothing to late initialize"
+      given:
+        desired_state: "v1alpha1/create/observed/success_after_create.yaml"
+        svc_api:
+          - operation: DescribeModelExplainabilityJobDefinitionWithContext
+            output_fixture: "sdkapi/describe/success_describe.json"
+      invoke: LateInitialize
+      expect:
+        latest_state: "v1alpha1/create/observed/success_after_create.yaml"
     - name: "ReadOne=SuccessClearsConditions"
       description: Testing a successful reconciliation clears conditions if terminal/recoverable condition were already set to true
       given:

--- a/pkg/resource/model_package/testdata/sdkapi/describe/describe_versioned_success.json
+++ b/pkg/resource/model_package/testdata/sdkapi/describe/describe_versioned_success.json
@@ -1,0 +1,87 @@
+{
+    "ApprovalDescription": null,
+    "CertifyForMarketplace": false,
+    "CreatedBy": null,
+    "CreationTime": "2021-09-15T06:28:47.875Z",
+    "InferenceSpecification": {
+        "Containers": [
+            {
+                "ContainerHostname": null,
+                "Image": "433757028032.dkr.ecr.us-west-2.amazonaws.com/xgboost:latest",
+                "ImageDigest": "sha256:a219d35e7bc4158e972b8e6fa18028b05bdc97a9fe8da2ba16f7e3dc1bc685b4",
+                "ModelDataUrl": "s3://source-data-bucket-592697580195-us-west-2/sagemaker/model/xgboost-mnist-model.tar.gz",
+                "ProductId": null
+            }
+        ],
+        "SupportedContentTypes": [
+            "text/csv"
+        ],
+        "SupportedRealtimeInferenceInstanceTypes": [
+            "ml.m5.large"
+        ],
+        "SupportedResponseMIMETypes": [
+            "text/csv"
+        ],
+        "SupportedTransformInstanceTypes": [
+            "ml.m5.large"
+        ]
+    },
+    "LastModifiedBy": null,
+    "LastModifiedTime": null,
+    "MetadataProperties": null,
+    "ModelApprovalStatus": null,
+    "ModelMetrics": null,
+    "ModelPackageArn": "arn:aws:sagemaker:us-west-2:123456789012:model-package/xgboost-unversioned-model-package-test",
+    "ModelPackageDescription": "Description for model package",
+    "ModelPackageGroupName": "xgboost-model-package-group",
+    "ModelPackageName": null,
+    "ModelPackageStatus": "Completed",
+    "ModelPackageStatusDetails": {
+        "ImageScanStatuses": [],
+        "ValidationStatuses": [
+            {
+                "FailureReason": null,
+                "Name": "Test-Model-Package",
+                "Status": "Completed"
+            }
+        ]
+    },
+    "ModelPackageVersion": null,
+    "SourceAlgorithmSpecification": null,
+    "ValidationSpecification": {
+        "ValidationProfiles": [
+            {
+                "ProfileName": "Test-Model-Package",
+                "TransformJobDefinition": {
+                    "BatchStrategy": null,
+                    "Environment": null,
+                    "MaxConcurrentTransforms": null,
+                    "MaxPayloadInMB": null,
+                    "TransformInput": {
+                        "CompressionType": null,
+                        "ContentType": "text/csv",
+                        "DataSource": {
+                            "S3DataSource": {
+                                "S3DataType": "S3Prefix",
+                                "S3Uri": "s3://source-data-bucket-592697580195-us-west-2/sagemaker/batch/input-data"
+                            }
+                        },
+                        "SplitType": null
+                    },
+                    "TransformOutput": {
+                        "Accept": null,
+                        "AssembleWith": null,
+                        "KmsKeyId": "",
+                        "S3OutputPath": "s3://source-data-bucket-592697580195-us-west-2/sagemaker/batch/output"
+                    },
+                    "TransformResources": {
+                        "InstanceCount": 1,
+                        "InstanceType": "ml.m5.large",
+                        "VolumeKmsKeyId": null
+                    }
+                }
+            }
+        ],
+        "ValidationRole": "arn:aws:iam::123456789012:role/ack-sagemaker-execution-role-83w8wvq6kyyke4a7ns0e167ha5c5fndodr"
+    }
+}

--- a/pkg/resource/model_package/testdata/test_suite.yaml
+++ b/pkg/resource/model_package/testdata/test_suite.yaml
@@ -123,6 +123,16 @@
         invoke: ReadOne
         expect:
           latest_state: "v1alpha1/readone/observed/created.yaml"
+      - name: "ReadOne=LateInitialize"
+        description: "Verifies that LateInitialize condition is set as successful"
+        given:
+          desired_state: "v1alpha1/create/observed/success_after_create_versioned.yaml"
+          svc_api:
+            - operation: DescribeModelPackageWithContext
+              output_fixture: "sdkapi/describe/describe_variation_success.json"
+        invoke: LateInitialize
+        expect:
+          latest_state: "v1alpha1/readone/observed/late_initialize_versioned.yaml"
       - name: "ReadOne=AfterCreateVariation"
         description: "Testing readOne after create with different inputs, the status should have ARN."
         given:

--- a/pkg/resource/model_package/testdata/v1alpha1/readone/observed/late_initialize_versioned.yaml
+++ b/pkg/resource/model_package/testdata/v1alpha1/readone/observed/late_initialize_versioned.yaml
@@ -1,0 +1,48 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: ModelPackage
+metadata:
+  creationTimestamp: null
+  name: unit-testing-model-package
+spec:
+  certifyForMarketplace: false
+  inferenceSpecification:
+    containers:
+    - image: 433757028032.dkr.ecr.us-west-2.amazonaws.com/xgboost:latest
+      modelDataURL: s3://source-data-bucket-592697580195-us-west-2/sagemaker/model/xgboost-mnist-model.tar.gz
+    supportedContentTypes:
+    - text/csv
+    supportedRealtimeInferenceInstanceTypes:
+    - ml.m5.large
+    supportedResponseMIMETypes:
+    - text/csv
+    supportedTransformInstanceTypes:
+    - ml.m5.large
+  modelApprovalStatus: PendingManualApproval
+  modelPackageDescription: Description for model package
+  modelPackageGroupName: xgboost-model-package-group
+  validationSpecification:
+    validationProfiles:
+    - profileName: Test-Model-Package
+      transformJobDefinition:
+        transformInput:
+          contentType: text/csv
+          dataSource:
+            s3DataSource:
+              s3DataType: S3Prefix
+              s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/batch/input-data
+        transformOutput:
+          s3OutputPath: s3://source-data-bucket-592697580195-us-west-2/sagemaker/batch/output
+        transformResources:
+          instanceCount: 1
+          instanceType: ml.m5.large
+    validationRole: arn:aws:iam::123456789012:role/ack-sagemaker-execution-role
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:model-package/xgboost-model-package-group/1
+    ownerAccountID: ""
+  conditions:
+  - lastTransitionTime: "0001-01-01T00:00:00Z"
+    message: Late initialization successful
+    reason: Late initialization successful
+    status: "True"
+    type: ACK.LateInitialized

--- a/pkg/resource/model_package_group/testdata/test_suite.yaml
+++ b/pkg/resource/model_package_group/testdata/test_suite.yaml
@@ -71,6 +71,16 @@
         invoke: ReadOne
         expect:
           latest_state: "v1alpha1/readone/observed/pending_after_create.yaml"
+      - name: "ReadOne=LateInitialize"
+        description: "Testing late initialize after created, should expect no diff since there is nothing to late initialize"
+        given: 
+          desired_state: "v1alpha1/readone/observed/pending_after_create.yaml"
+          svc_api:
+            - operation: DescribeModelPackageGroupWithContext
+              output_fixture: "sdkapi/describe/describe_pending_after_create.json"
+        invoke: LateInitialize
+        expect:
+          latest_state: "v1alpha1/readone/observed/pending_after_create.yaml"
       - name: "ReadOne=Deleting"
         description: "Testing readone when deleting, resource synced should be false."
         given: 

--- a/pkg/resource/model_quality_job_definition/testdata/test_suite.yaml
+++ b/pkg/resource/model_quality_job_definition/testdata/test_suite.yaml
@@ -71,6 +71,16 @@ tests:
       invoke: ReadOne
       expect:
         latest_state: "v1alpha1/create/observed/success_after_create.yaml"
+    - name: "ReadOne=LateInitialize"
+      description: "Testing late initialize after created, should expect no diff since there is nothing to late initialize"
+      given:
+        desired_state: "v1alpha1/create/observed/success_after_create.yaml"
+        svc_api:
+          - operation: DescribeModelQualityJobDefinitionWithContext
+            output_fixture: "sdkapi/describe/success_describe.json"
+      invoke: LateInitialize
+      expect:
+        latest_state: "v1alpha1/create/observed/success_after_create.yaml"
     - name: "ReadOne=SuccessClearsConditions"
       description: Testing a successful reconciliation clears conditions if terminal/recoverable condition were already set to true
       given:

--- a/pkg/resource/monitoring_schedule/testdata/test_suite.yaml
+++ b/pkg/resource/monitoring_schedule/testdata/test_suite.yaml
@@ -71,6 +71,16 @@ tests:
         invoke: ReadOne
         expect:
           latest_state: "v1alpha1/readone/observed/scheduled.yaml"
+      - name: "ReadOne=LateInitialize"
+        description: "Testing late initialize after created, should expect no diff since there is nothing to late initialize"
+        given:
+          desired_state: "v1alpha1/readone/observed/scheduled.yaml"
+          svc_api:
+            - operation: DescribeMonitoringScheduleWithContext
+              output_fixture: "sdkapi/describe/scheduled_describe.json"
+        invoke: LateInitialize
+        expect:
+          latest_state: "v1alpha1/readone/observed/scheduled.yaml"
       - name: "ReadOne=SuccessClearsConditions"
         description: Testing a successful reconciliation clears conditions if terminal/recoverable condition were already set to true
         given:

--- a/pkg/resource/notebook_instance/testdata/test_suite.yaml
+++ b/pkg/resource/notebook_instance/testdata/test_suite.yaml
@@ -38,6 +38,16 @@ tests:
          invoke: ReadOne
          expect:
            latest_state: "v1alpha1/readone/observed/nb_readone_pending_after_create.yaml"
+       - name: "ReadOne=LateInitialize"
+         description: "Testing late initialize after created, should expect no diff since there is nothing to late initialize"
+         given: 
+           desired_state: "v1alpha1/readone/observed/nb_readone_pending_after_create.yaml"
+           svc_api:
+             - operation: DescribeNotebookInstanceWithContext
+               output_fixture: "sdkapi/readone/readone_pending_after_create.json"
+         invoke: LateInitialize
+         expect:
+           latest_state: "v1alpha1/readone/observed/nb_readone_pending_after_create.yaml"
        - name: "ReadOne=Deleting"
          description: "Testing readone when deleting, resource synced should be false."
          given: 

--- a/pkg/resource/notebook_instance_lifecycle_config/testdata/test_suite.yaml
+++ b/pkg/resource/notebook_instance_lifecycle_config/testdata/test_suite.yaml
@@ -81,6 +81,16 @@ tests:
         invoke: ReadOne
         expect:
           latest_state: "v1alpha1/readone/observed/creating_after_describe.yaml"
+      - name: "ReadOne=LateInitialize"
+        description: "Testing late initialize after created, should expect no diff since there is nothing to late initialize"
+        given:
+          desired_state: "v1alpha1/readone/observed/creating_after_describe.yaml"
+          svc_api:
+            - operation: DescribeNotebookInstanceLifecycleConfigWithContext
+              output_fixture: "sdkapi/describe/success_describe.json"
+        invoke: LateInitialize
+        expect:
+          latest_state: "v1alpha1/readone/observed/creating_after_describe.yaml"
   - name: "Notebook instance lifecycle config update tests"
     description: "Testing the Update operation"
     scenarios:

--- a/pkg/resource/processing_job/testdata/test_suite.yaml
+++ b/pkg/resource/processing_job/testdata/test_suite.yaml
@@ -92,6 +92,16 @@
         invoke: ReadOne
         expect:
           latest_state: "v1alpha1/readone/observed/created.yaml"
+      - name: "ReadOne=LateInitialize"
+        description: "Testing late initialize after created, should expect no diff since there is nothing to late initialize"
+        given:
+          desired_state: "v1alpha1/readone/observed/created.yaml"
+          svc_api:
+            - operation: DescribeProcessingJobWithContext
+              output_fixture: "sdkapi/describe/success_describe.json"
+        invoke: LateInitialize
+        expect:
+          latest_state: "v1alpha1/readone/observed/created.yaml"
       - name: "ReadOne=AfterCompletion"
         description: "Testing readOne after processing job completes, the status should have ARN."
         given:

--- a/pkg/resource/training_job/testdata/test_suite.yaml
+++ b/pkg/resource/training_job/testdata/test_suite.yaml
@@ -92,6 +92,16 @@ tests:
         invoke: ReadOne
         expect:
           latest_state: "v1alpha1/readone/observed/created.yaml"
+      - name: "ReadOne=LateInitialize"
+        description: "Verifies that LateInitialize condition is set as successful"
+        given:
+          desired_state: "v1alpha1/readone/observed/created.yaml"
+          svc_api:
+            - operation: DescribeTrainingJobWithContext
+              output_fixture: "sdkapi/describe/inprogress_describe.json"
+        invoke: LateInitialize
+        expect:
+          latest_state: "v1alpha1/readone/observed/late_initialize.yaml"
       - name: "ReadOne=AfterCompletion"
         description: "Testing readOne after Training job completes, the status should have ARN and be in completed state"
         given:

--- a/pkg/resource/training_job/testdata/v1alpha1/readone/observed/late_initialize.yaml
+++ b/pkg/resource/training_job/testdata/v1alpha1/readone/observed/late_initialize.yaml
@@ -1,0 +1,112 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: TrainingJob
+metadata:
+  creationTimestamp: null
+  name: unit-testing-training-job
+spec:
+  algorithmSpecification:
+    enableSageMakerMetricsTimeSeries: false
+    metricDefinitions:
+    - name: train:mae
+      regex: .*\[[0-9]+\].*#011train-mae:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: validation:auc
+      regex: .*\[[0-9]+\].*#011validation-auc:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: train:merror
+      regex: .*\[[0-9]+\].*#011train-merror:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: train:auc
+      regex: .*\[[0-9]+\].*#011train-auc:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: validation:mae
+      regex: .*\[[0-9]+\].*#011validation-mae:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: validation:error
+      regex: .*\[[0-9]+\].*#011validation-error:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: validation:merror
+      regex: .*\[[0-9]+\].*#011validation-merror:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: validation:logloss
+      regex: .*\[[0-9]+\].*#011validation-logloss:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: train:rmse
+      regex: .*\[[0-9]+\].*#011train-rmse:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: train:logloss
+      regex: .*\[[0-9]+\].*#011train-logloss:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: train:mlogloss
+      regex: .*\[[0-9]+\].*#011train-mlogloss:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: validation:rmse
+      regex: .*\[[0-9]+\].*#011validation-rmse:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: validation:ndcg
+      regex: .*\[[0-9]+\].*#011validation-ndcg:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: train:error
+      regex: .*\[[0-9]+\].*#011train-error:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: validation:mlogloss
+      regex: .*\[[0-9]+\].*#011validation-mlogloss:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: train:ndcg
+      regex: .*\[[0-9]+\].*#011train-ndcg:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: train:map
+      regex: .*\[[0-9]+\].*#011train-map:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    - name: validation:map
+      regex: .*\[[0-9]+\].*#011validation-map:([-+]?[0-9]*\.?[0-9]+(?:[eE][-+]?[0-9]+)?).*
+    trainingImage: 433757028032.dkr.ecr.us-west-2.amazonaws.com/xgboost:1
+    trainingInputMode: File
+  enableInterContainerTrafficEncryption: false
+  enableManagedSpotTraining: false
+  enableNetworkIsolation: false
+  hyperParameters:
+    eta: "0.2"
+    gamma: "4"
+    max_depth: "5"
+    min_child_weight: "6"
+    num_class: "10"
+    num_round: "10"
+    objective: multi:softmax
+    silent: "0"
+  inputDataConfig:
+  - channelName: train
+    compressionType: None
+    contentType: text/csv
+    dataSource:
+      s3DataSource:
+        s3DataDistributionType: FullyReplicated
+        s3DataType: S3Prefix
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/training/train
+    recordWrapperType: None
+  - channelName: validation
+    compressionType: None
+    contentType: text/csv
+    dataSource:
+      s3DataSource:
+        s3DataDistributionType: FullyReplicated
+        s3DataType: S3Prefix
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/training/validation
+    recordWrapperType: None
+  outputDataConfig:
+    kmsKeyID: ""
+    s3OutputPath: s3://source-data-bucket-592697580195-us-west-2/sagemaker/training/output
+  resourceConfig:
+    instanceCount: 1
+    instanceType: ml.m4.xlarge
+    volumeSizeInGB: 5
+  roleARN: arn:aws:iam::123456789012:role/service-role/AmazonSageMaker
+  stoppingCondition:
+    maxRuntimeInSeconds: 86400
+  tags:
+  - key: algorithm
+    value: xgboost
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user
+  trainingJobName: xgboost-training-jobsa
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:training-job/xgboost-training-jobsa
+    ownerAccountID: ""
+  conditions:
+  - lastTransitionTime: null
+    message: TrainingJob is in InProgress status.
+    status: "False"
+    type: ACK.ResourceSynced
+  - lastTransitionTime: "0001-01-01T00:00:00Z"
+    message: Late initialization successful
+    reason: Late initialization successful
+    status: "True"
+    type: ACK.LateInitialized
+  secondaryStatus: Downloading
+  trainingJobStatus: InProgress

--- a/pkg/resource/training_job/testdata/v1alpha1/readone/observed/late_initialize.yaml
+++ b/pkg/resource/training_job/testdata/v1alpha1/readone/observed/late_initialize.yaml
@@ -99,8 +99,7 @@ status:
     arn: arn:aws:sagemaker:us-west-2:123456789012:training-job/xgboost-training-jobsa
     ownerAccountID: ""
   conditions:
-  - lastTransitionTime: null
-    message: TrainingJob is in InProgress status.
+  - message: TrainingJob is in InProgress status.
     status: "False"
     type: ACK.ResourceSynced
   - lastTransitionTime: "0001-01-01T00:00:00Z"

--- a/pkg/resource/transform_job/testdata/test_suite.yaml
+++ b/pkg/resource/transform_job/testdata/test_suite.yaml
@@ -81,6 +81,16 @@ tests:
         invoke: ReadOne
         expect:
           latest_state: "v1alpha1/readone/observed/created.yaml"
+      - name: "ReadOne=LateInitialize"
+        description: "Verifies that LateInitialize condition is set as successful"
+        given:
+          desired_state: "v1alpha1/readone/observed/created.yaml"
+          svc_api:
+            - operation: DescribeTransformJobWithContext
+              output_fixture: "sdkapi/describe/inprogress_describe.json"
+        invoke: LateInitialize
+        expect:
+          latest_state: "v1alpha1/readone/observed/late_initialize.yaml"
       - name: "ReadOne=AfterCompletion"
         description: "Testing readOne after transform job completes, the status should have ARN."
         given:

--- a/pkg/resource/transform_job/testdata/v1alpha1/readone/observed/late_initialize.yaml
+++ b/pkg/resource/transform_job/testdata/v1alpha1/readone/observed/late_initialize.yaml
@@ -37,8 +37,7 @@ status:
     arn: arn:aws:sagemaker:us-west-2:123456789012:transform-job/xgboost-transform-job
     ownerAccountID: ""
   conditions:
-  - lastTransitionTime: null
-    message: TransformJob is in InProgress status.
+  - message: TransformJob is in InProgress status.
     status: "False"
     type: ACK.ResourceSynced
   - lastTransitionTime: "0001-01-01T00:00:00Z"

--- a/pkg/resource/transform_job/testdata/v1alpha1/readone/observed/late_initialize.yaml
+++ b/pkg/resource/transform_job/testdata/v1alpha1/readone/observed/late_initialize.yaml
@@ -1,0 +1,49 @@
+apiVersion: sagemaker.services.k8s.aws/v1alpha1
+kind: TransformJob
+metadata:
+  creationTimestamp: null
+  name: unit-testing-transform-job
+spec:
+  dataProcessing:
+    inputFilter: $
+    joinSource: None
+    outputFilter: $
+  modelName: xgboost-churn-config-model
+  tags:
+  - key: algorithm
+    value: xgboost
+  - key: environment
+    value: testing
+  - key: customer
+    value: test-user
+  transformInput:
+    compressionType: None
+    contentType: text/csv
+    dataSource:
+      s3DataSource:
+        s3DataType: S3Prefix
+        s3URI: s3://source-data-bucket-592697580195-us-west-2/sagemaker/batch/input-data
+    splitType: None
+  transformJobName: xgboost-transform-job
+  transformOutput:
+    assembleWith: None
+    kmsKeyID: ""
+    s3OutputPath: s3://source-data-bucket-592697580195-us-west-2/sagemaker/batch/output
+  transformResources:
+    instanceCount: 1
+    instanceType: ml.m5.large
+status:
+  ackResourceMetadata:
+    arn: arn:aws:sagemaker:us-west-2:123456789012:transform-job/xgboost-transform-job
+    ownerAccountID: ""
+  conditions:
+  - lastTransitionTime: null
+    message: TransformJob is in InProgress status.
+    status: "False"
+    type: ACK.ResourceSynced
+  - lastTransitionTime: "0001-01-01T00:00:00Z"
+    message: Late initialization successful
+    reason: Late initialization successful
+    status: "True"
+    type: ACK.LateInitialized
+  transformJobStatus: InProgress

--- a/pkg/testutil/test_suite_runner.go
+++ b/pkg/testutil/test_suite_runner.go
@@ -108,6 +108,8 @@ func (runner *TestSuiteRunner) runTestScenario(t *testing.T, scenarioName string
 		actual, err = rm.Update(context.Background(), fixtureCxt.desired, fixtureCxt.latest, delta)
 	case "Delete":
 		actual, err = rm.Delete(context.Background(), fixtureCxt.desired)
+	case "LateInitialize":
+		actual, err = rm.LateInitialize(context.Background(), fixtureCxt.desired)
 	default:
 		panic(errors.New(fmt.Sprintf("unit under test: %s not supported", unitUnderTest)))
 	}


### PR DESCRIPTION
Description of changes:

- Adds `LateInitialize` to `test_suite_runner.go`
- Adds `LateInitialize` unit tests which invoke `LateInitialize`
   - Majority of resources do not use `LateInitialize` so there will be no difference in the latest resource.
      
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
