### PR TITLE
Increasing time out for SageMaker HPO tests

### DIFF
--- a/test/e2e/tests/test_hpo.py
+++ b/test/e2e/tests/test_hpo.py
@@ -91,7 +91,7 @@ class TestHPO:
         self,
         reference: k8s.CustomResourceReference,
         expected_status: str,
-        wait_periods: int = 45,
+        wait_periods: int = 90,
         period_length: int = 30,
     ):
         return wait_for_status(
@@ -106,7 +106,7 @@ class TestHPO:
         self,
         hpo_job_name,
         expected_status: str,
-        wait_periods: int = 45,
+        wait_periods: int = 90,
         period_length: int = 30,
     ):
         return wait_for_status(


### PR DESCRIPTION
HPO jobs are timing out recently. Bumping the timeout for hpo jobs.

Error:
```
tests/test_hpo.py:121: AssertionError
------------------------------ Captured log call -------------------------------
INFO     root:resource.py:311 Condition ACK.ResourceSynced has status False, continuing...
ERROR    root:__init__.py:109 Wait for status: Completed timed out. Actual status: InProgress'
```

