### PR TITLE
increase hpo parallel training jobs to 2

### DIFF
--- a/test/e2e/resources/xgboost_hpojob.yaml
+++ b/test/e2e/resources/xgboost_hpojob.yaml
@@ -11,7 +11,7 @@ spec:
       metricName: validation:error
     resourceLimits:
       maxNumberOfTrainingJobs: 2
-      maxParallelTrainingJobs: 1
+      maxParallelTrainingJobs: 2
     parameterRanges:
       integerParameterRanges:
       - name: num_round


### PR DESCRIPTION
Issue #, if available:
see conversation on #144. Although I don't see any technical reason to have 2 training jobs in this test, I will disagree and commit to increasing the parallel job count for now so the jobs do not run serially

Testing:
PR build

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
