### PR TITLE
Use new object oriented bootstrapping resource in e2e tests

### DIFF
--- a/test/e2e/bootstrap_resources.py
+++ b/test/e2e/bootstrap_resources.py
@@ -15,27 +15,30 @@ for them.
 """
 
 from dataclasses import dataclass
-from acktest.resources import read_bootstrap_config
+from acktest.bootstrapping import Resources
+from acktest.bootstrapping.iam import Role
+from acktest.bootstrapping.s3 import Bucket
 from e2e import bootstrap_directory
 
 SAGEMAKER_SOURCE_DATA_BUCKET = "source-data-bucket-592697580195-us-west-2"
 
 
 @dataclass
-class TestBootstrapResources:
-    DataBucketName: str
-    ExecutionRoleARN: str
+class TestBootstrapResources(Resources):
+    DataBucket: Bucket
+    ExecutionRole: Role
 
 
 _bootstrap_resources = None
 
 
-def get_bootstrap_resources(bootstrap_file_name: str = "bootstrap.yaml"):
+def get_bootstrap_resources(
+    bootstrap_file_name: str = "bootstrap.pkl",
+) -> TestBootstrapResources:
+    global _bootstrap_resources
     global _bootstrap_resources
     if _bootstrap_resources is None:
-        _bootstrap_resources = TestBootstrapResources(
-            **read_bootstrap_config(
-                bootstrap_directory, bootstrap_file_name=bootstrap_file_name
-            ),
+        _bootstrap_resources = TestBootstrapResources.deserialize(
+            bootstrap_directory, bootstrap_file_name=bootstrap_file_name
         )
     return _bootstrap_resources

--- a/test/e2e/replacement_values.py
+++ b/test/e2e/replacement_values.py
@@ -181,12 +181,12 @@ NOTEBOOK_INSTANCE_INSTANCE_TYPES = {
 }
 
 REPLACEMENT_VALUES = {
-    "SAGEMAKER_DATA_BUCKET": get_bootstrap_resources().DataBucketName,
+    "SAGEMAKER_DATA_BUCKET": get_bootstrap_resources().DataBucket.name,
     "XGBOOST_IMAGE_URI": f"{XGBOOST_IMAGE_URIS[get_region()]}/sagemaker-xgboost:1.0-1-cpu-py3",
     "DEBUGGER_IMAGE_URI": f"{DEBUGGER_IMAGE_URIS[get_region()]}/sagemaker-debugger-rules:latest",
     "XGBOOST_V1_IMAGE_URI": f"{XGBOOST_V1_IMAGE_URIS[get_region()]}/xgboost:latest",
     "PYTORCH_TRAIN_IMAGE_URI": f"{PYTORCH_TRAIN_IMAGE_URIS[get_region()]}/pytorch-training:1.5.0-cpu-py36-ubuntu16.04",
-    "SAGEMAKER_EXECUTION_ROLE_ARN": get_bootstrap_resources().ExecutionRoleARN,
+    "SAGEMAKER_EXECUTION_ROLE_ARN": get_bootstrap_resources().ExecutionRole.arn,
     "MODEL_MONITOR_ANALYZER_IMAGE_URI": f"{MODEL_MONITOR_IMAGE_URIS[get_region()]}/sagemaker-model-monitor-analyzer",
     "CLARIFY_IMAGE_URI": f"{CLARIFY_IMAGE_URIS[get_region()]}/sagemaker-clarify-processing:1.0",
     "ENDPOINT_INSTANCE_TYPE": ENDPOINT_INSTANCE_TYPES.get(get_region(), "ml.c5.large"),

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,2 +1,2 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@6045316542f9699db4aba2829fa0c394eebae8e8
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@835781dcbb39e2220e68a659dd771ce4bd9b1ac0
 black==20.8b1

--- a/test/e2e/service_cleanup.py
+++ b/test/e2e/service_cleanup.py
@@ -13,72 +13,20 @@
 """Cleans up the resources created by the SageMaker bootstrapping process.
 """
 
-import re
-import boto3
+
 import logging
 
-from acktest import resources
-from acktest.aws.identity import get_region
+from acktest.bootstrapping import Resources
 
 from e2e import bootstrap_directory
-from e2e.bootstrap_resources import TestBootstrapResources
-
-# Regex to match the role name from a role ARN
-IAM_ROLE_ARN_REGEX = r"^arn:aws:iam::\d{12}:(?:root|user|role\/([A-Za-z0-9-]+))$"
 
 
-def delete_execution_role(role_arn: str):
-    region = get_region()
-    iam = boto3.client("iam", region_name=region)
-
-    role_name = re.match(IAM_ROLE_ARN_REGEX, role_arn).group(1)
-    managedPolicy = iam.list_attached_role_policies(RoleName=role_name)
-    for each in managedPolicy["AttachedPolicies"]:
-        iam.detach_role_policy(RoleName=role_name, PolicyArn=each["PolicyArn"])
-
-    inlinePolicy = iam.list_role_policies(RoleName=role_name)
-    for each in inlinePolicy["PolicyNames"]:
-        iam.delete_role_policy(RoleName=role_name, PolicyName=each)
-
-    instanceProfiles = iam.list_instance_profiles_for_role(RoleName=role_name)
-    for each in instanceProfiles["InstanceProfiles"]:
-        iam.remove_role_from_instance_profile(
-            RoleName=role_name, InstanceProfileName=each["InstanceProfileName"]
-        )
-    iam.delete_role(RoleName=role_name)
-
-    logging.info(f"Deleted SageMaker execution role {role_name}")
-
-
-def delete_data_bucket(bucket_name: str):
-    region = get_region()
-    s3_resource = boto3.resource("s3", region_name=region)
-
-    bucket = s3_resource.Bucket(bucket_name)
-    bucket.objects.all().delete()
-    bucket.delete()
-
-    logging.info(f"Deleted data bucket {bucket_name}")
-
-
-def service_cleanup(config: dict):
+def service_cleanup():
     logging.getLogger().setLevel(logging.INFO)
 
-    resources = TestBootstrapResources(**config)
-
-    try:
-        delete_data_bucket(resources.DataBucketName)
-    except:
-        logging.exception(f"Unable to delete data bucket {resources.DataBucketName}")
-
-    try:
-        delete_execution_role(resources.ExecutionRoleARN)
-    except:
-        logging.exception(
-            f"Unable to delete execution role {resources.ExecutionRoleARN}"
-        )
+    resources = Resources.deserialize(bootstrap_directory)
+    resources.cleanup()
 
 
 if __name__ == "__main__":
-    bootstrap_config = resources.read_bootstrap_config(bootstrap_directory)
-    service_cleanup(bootstrap_config)
+    service_cleanup()


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/test-infra/pull/63
Description of changes:

- Pointing to new version of acktest old method of using bootstrapping is replaced
  - Updating existing methods to use the new OOP style


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
