### PR TITLE
Fix canary tests v0.3.0

### DIFF
--- a/test/canary/scripts/run_test.sh
+++ b/test/canary/scripts/run_test.sh
@@ -85,5 +85,5 @@ pushd $E2E_DIR
 
   # run tests
   echo "Run Tests"
-  pytest -n 10 --dist loadfile --log-cli-level INFO -m canary
+  pytest -n 15 --dist loadfile --log-cli-level INFO -m canary
 popd

--- a/test/e2e/__init__.py
+++ b/test/e2e/__init__.py
@@ -280,7 +280,7 @@ def get_training_resource_status(reference: k8s.CustomResourceReference):
 def wait_resource_training_status(
     reference: k8s.CustomResourceReference,
     expected_status: str,
-    wait_periods: int = 30,
+    wait_periods: int = 60,
     period_length: int = 30,
 ):
     return wait_for_status(
@@ -295,7 +295,7 @@ def wait_resource_training_status(
 def wait_sagemaker_training_status(
     training_job_name,
     expected_status: str,
-    wait_periods: int = 30,
+    wait_periods: int = 60,
     period_length: int = 30,
 ):
     return wait_for_status(

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,2 +1,3 @@
 acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@6045316542f9699db4aba2829fa0c394eebae8e8
 black==20.8b1
+flaky==3.7.0

--- a/test/e2e/resources/xgboost_hpojob.yaml
+++ b/test/e2e/resources/xgboost_hpojob.yaml
@@ -11,7 +11,7 @@ spec:
       metricName: validation:error
     resourceLimits:
       maxNumberOfTrainingJobs: 2
-      maxParallelTrainingJobs: 1
+      maxParallelTrainingJobs: 2
     parameterRanges:
       integerParameterRanges:
       - name: num_round

--- a/test/e2e/tests/test_notebook_instance.py
+++ b/test/e2e/tests/test_notebook_instance.py
@@ -27,7 +27,9 @@ from e2e import (
     sagemaker_client,
 )
 from e2e.replacement_values import REPLACEMENT_VALUES
+from flaky import flaky
 import random
+
 
 DELETE_WAIT_PERIOD = 16
 DELETE_WAIT_LENGTH = 30
@@ -84,6 +86,7 @@ def get_notebook_instance_resource_status(reference: k8s.CustomResourceReference
     return resource["status"]["notebookInstanceStatus"]
 
 
+@flaky
 @pytest.mark.canary
 @service_marker
 class TestNotebookInstance:

--- a/test/e2e/tests/test_processingjob.py
+++ b/test/e2e/tests/test_processingjob.py
@@ -91,7 +91,7 @@ class TestProcessingJob:
         self,
         reference: k8s.CustomResourceReference,
         expected_status: str,
-        wait_periods: int = 30,
+        wait_periods: int = 60,
         period_length: int = 30,
     ):
         return wait_for_status(
@@ -106,7 +106,7 @@ class TestProcessingJob:
         self,
         processing_job_name,
         expected_status: str,
-        wait_periods: int = 30,
+        wait_periods: int = 60,
         period_length: int = 30,
     ):
         return wait_for_status(


### PR DESCRIPTION
1] Cherry-pick some of the fixes from main
2] For all notebook tests retry failed tests once 
