### PR TITLE
Fix awscli and kubectl versions to stable version for canary

### DIFF
--- a/test/canary/Dockerfile.canary
+++ b/test/canary/Dockerfile.canary
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y curl \
     unzip
 
 # Install awscli
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.6.3.zip" -o "awscliv2.zip" \
  && unzip -qq awscliv2.zip \
  && ./aws/install
 
@@ -25,7 +25,7 @@ RUN apt-get update && apt install -y software-properties-common \
  && apt update && apt install -y yq
 
 # Install kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl \
+RUN  curl -LO "https://dl.k8s.io/release/v1.24.0/bin/linux/amd64/kubectl" \
  && chmod +x ./kubectl \
  && cp ./kubectl /bin
 


### PR DESCRIPTION
Description of changes:

Canaries are failing due to:
```
Empty KUBERNETES_EXEC_INFO, defaulting to client.authentication.k8s.io/v1alpha1. This is likely a bug in your Kubernetes client. Please update your Kubernetes client.
Unable to connect to the server: getting credentials: exec plugin is configured to use API version client.authentication.k8s.io/v1beta1, plugin returned version client.authentication.k8s.io/v1alpha1
```

We started seeing this failure due to changes with `aws-iam-authenticator` which is packaged with awscli. The `aws-iam-authenticator` expects `client.authentication.k8s.io/v1beta1` as `client.authentication.k8s.io/v1alpha1` is no longer supported as of kubernetes 1.23. 

The latests awscli version (2.6.3) now sets `client.authentication.k8s.io/v1beta1` as the API version to address the issue with `aws-iam-authenticator`. 
However, to use `client.authentication.k8s.io/v1beta1` in the exec plugin, we also need to update the kubectl version. 

This PR takes care of both and fixes the canary failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Test results:
https://eu-west-1.console.aws.amazon.com/codesuite/codebuild/464333445967/projects/CodeBuild-Run-All-Tests/build/CodeBuild-Run-All-Tests%3A456a57e6-956b-424d-a7ff-af75c7d803bb?region=eu-west-1
