### PR TITLE
Fix awscli and kubectl versions to stable version for canary

### DIFF
--- a/test/canary/Dockerfile.canary
+++ b/test/canary/Dockerfile.canary
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y curl \
     unzip
 
 # Install awscli
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.6.3.zip" -o "awscliv2.zip" \
  && unzip -qq awscliv2.zip \
  && ./aws/install
 
@@ -25,7 +25,7 @@ RUN apt-get update && apt install -y software-properties-common \
  && apt update && apt install -y yq
 
 # Install kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl \
+RUN  curl -LO "https://dl.k8s.io/release/v1.24.0/bin/linux/amd64/kubectl" \
  && chmod +x ./kubectl \
  && cp ./kubectl /bin
 


### PR DESCRIPTION
Same changes as https://github.com/aws-controllers-k8s/sagemaker-controller/pull/155

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
