### PR TITLE
release artifacts for release v0.4.0

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2022-08-10T19:05:39Z"
+  build_date: "2022-08-11T01:56:21Z"
   build_hash: fe61d04673fd4d9848d5f726b01e0689a16d3733
   go_version: go1.17.1
   version: v0.19.3-1-gfe61d04
-api_directory_checksum: 20cd27e38433f0573cb927503ef2be4be5a92b68
+api_directory_checksum: 8b3c128d2037d5227679cccb57cd4d78af6aed1b
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.28
 generator_config_info:

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/sagemaker-controller
-  newTag: v0.3.4
+  newTag: v0.4.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: sagemaker-chart
 description: A Helm chart for the ACK service controller for Amazon SageMaker (SageMaker)
-version: v0.3.4
-appVersion: v0.3.4
+version: v0.4.0
+appVersion: v0.4.0
 home: https://github.com/aws-controllers-k8s/sagemaker-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/sagemaker-controller:v0.3.4".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/sagemaker-controller:v0.4.0".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/sagemaker-controller
-  tag: v0.3.4
+  tag: v0.4.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Release Notes Draft:

Updated aws-sdk-go to v1.42.28 version which supports ml.g5 training-job instances.

Additional Fields for ModelPackage
- AdditionalInferenceSpecifications 
- SamplePayloadURL
- Domain

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
