### PR TITLE
Fix delta bug

### DIFF
--- a/pkg/resource/training_job/custom_delta.go
+++ b/pkg/resource/training_job/custom_delta.go
@@ -28,7 +28,7 @@ func customSetDefaults(
 
 	if ackcompare.IsNotNil(a.ko.Spec.ProfilerRuleConfigurations) && ackcompare.IsNotNil(b.ko.Spec.ProfilerRuleConfigurations) {
 		for index := range a.ko.Spec.ProfilerRuleConfigurations {
-			if ackcompare.IsNil(a.ko.Spec.ProfilerRuleConfigurations[index].VolumeSizeInGB) && ackcompare.IsNotNil(b.ko.Spec.DebugRuleConfigurations[index].VolumeSizeInGB) {
+			if ackcompare.IsNil(a.ko.Spec.ProfilerRuleConfigurations[index].VolumeSizeInGB) && ackcompare.IsNotNil(b.ko.Spec.ProfilerRuleConfigurations[index].VolumeSizeInGB) {
 				a.ko.Spec.ProfilerRuleConfigurations[index].VolumeSizeInGB = defaultVolumeSizeInGB
 			}
 		}


### PR DESCRIPTION
Issue #, if available:

If the user creates a training job with a profileRuleConfiguration but without a debugRuleConfiguration the controller crashes because it compares profileRuleConfiguration and debugRuleConfiguration(which could have a length of zero) and causes an index error. 

Steps to reproduce:

Run trainingjob with normal parameters(https://github.com/aws-controllers-k8s/sagemaker-controller/blob/main/samples/training/my-training-job.yaml) but with a profileRuleConfiguration and profilerConfig 

Description of changes:

Changes custom set defaults function to compare only profileRuleConfiguration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
