### PR TITLE
Fix late initialization field

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,7 +1,7 @@
 ack_generate_info:
-  build_date: "2022-08-17T21:08:22Z"
+  build_date: "2022-08-17T21:49:11Z"
   build_hash: fe61d04673fd4d9848d5f726b01e0689a16d3733
-  go_version: go1.17.7
+  go_version: go1.17.1
   version: v0.19.3-1-gfe61d04
 api_directory_checksum: 8b3c128d2037d5227679cccb57cd4d78af6aed1b
 api_version: v1alpha1

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-08-12T20:32:53Z"
+  build_date: "2022-08-17T21:08:22Z"
   build_hash: fe61d04673fd4d9848d5f726b01e0689a16d3733
-  go_version: go1.17.1
+  go_version: go1.17.7
   version: v0.19.3-1-gfe61d04
 api_directory_checksum: 8b3c128d2037d5227679cccb57cd4d78af6aed1b
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.28
 generator_config_info:
-  file_checksum: 92038dd37f8302115ea2733a22973f551e60c78e
+  file_checksum: b97e2519e420215d25350e3df27f956c482e828e
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -171,8 +171,8 @@ resources:
           operation: DescribeTrainingJob
           path: FailureReason 
       AlgorithmSpecification.MetricDefinitions:
-        late_initialize:
-          min_backoff_seconds: 5
+        compare:
+          is_ignored: true
       EnableInterContainerTrafficEncryption:
         late_initialize:
           min_backoff_seconds: 5

--- a/generator.yaml
+++ b/generator.yaml
@@ -171,8 +171,8 @@ resources:
           operation: DescribeTrainingJob
           path: FailureReason 
       AlgorithmSpecification.MetricDefinitions:
-        late_initialize:
-          min_backoff_seconds: 5
+        compare:
+          is_ignored: true
       EnableInterContainerTrafficEncryption:
         late_initialize:
           min_backoff_seconds: 5

--- a/pkg/resource/training_job/custom_delta.go
+++ b/pkg/resource/training_job/custom_delta.go
@@ -28,7 +28,7 @@ func customSetDefaults(
 
 	if ackcompare.IsNotNil(a.ko.Spec.ProfilerRuleConfigurations) && ackcompare.IsNotNil(b.ko.Spec.ProfilerRuleConfigurations) {
 		for index := range a.ko.Spec.ProfilerRuleConfigurations {
-			if ackcompare.IsNil(a.ko.Spec.ProfilerRuleConfigurations[index].VolumeSizeInGB) && ackcompare.IsNotNil(b.ko.Spec.DebugRuleConfigurations[index].VolumeSizeInGB) {
+			if ackcompare.IsNil(a.ko.Spec.ProfilerRuleConfigurations[index].VolumeSizeInGB) && ackcompare.IsNotNil(b.ko.Spec.ProfilerRuleConfigurations[index].VolumeSizeInGB) {
 				a.ko.Spec.ProfilerRuleConfigurations[index].VolumeSizeInGB = defaultVolumeSizeInGB
 			}
 		}

--- a/pkg/resource/training_job/delta.go
+++ b/pkg/resource/training_job/delta.go
@@ -59,9 +59,6 @@ func newResourceDelta(
 				delta.Add("Spec.AlgorithmSpecification.EnableSageMakerMetricsTimeSeries", a.ko.Spec.AlgorithmSpecification.EnableSageMakerMetricsTimeSeries, b.ko.Spec.AlgorithmSpecification.EnableSageMakerMetricsTimeSeries)
 			}
 		}
-		if !reflect.DeepEqual(a.ko.Spec.AlgorithmSpecification.MetricDefinitions, b.ko.Spec.AlgorithmSpecification.MetricDefinitions) {
-			delta.Add("Spec.AlgorithmSpecification.MetricDefinitions", a.ko.Spec.AlgorithmSpecification.MetricDefinitions, b.ko.Spec.AlgorithmSpecification.MetricDefinitions)
-		}
 		if ackcompare.HasNilDifference(a.ko.Spec.AlgorithmSpecification.TrainingImage, b.ko.Spec.AlgorithmSpecification.TrainingImage) {
 			delta.Add("Spec.AlgorithmSpecification.TrainingImage", a.ko.Spec.AlgorithmSpecification.TrainingImage, b.ko.Spec.AlgorithmSpecification.TrainingImage)
 		} else if a.ko.Spec.AlgorithmSpecification.TrainingImage != nil && b.ko.Spec.AlgorithmSpecification.TrainingImage != nil {

--- a/pkg/resource/training_job/manager.go
+++ b/pkg/resource/training_job/manager.go
@@ -51,7 +51,7 @@ var (
 // +kubebuilder:rbac:groups=sagemaker.services.k8s.aws,resources=trainingjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=sagemaker.services.k8s.aws,resources=trainingjobs/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"AlgorithmSpecification.EnableSageMakerMetricsTimeSeries", "AlgorithmSpecification.MetricDefinitions", "EnableInterContainerTrafficEncryption", "EnableManagedSpotTraining", "EnableNetworkIsolation", "OutputDataConfig.KMSKeyID"}
+var lateInitializeFieldNames = []string{"AlgorithmSpecification.EnableSageMakerMetricsTimeSeries", "EnableInterContainerTrafficEncryption", "EnableManagedSpotTraining", "EnableNetworkIsolation", "OutputDataConfig.KMSKeyID"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -254,11 +254,6 @@ func (rm *resourceManager) incompleteLateInitialization(
 			return true
 		}
 	}
-	if ko.Spec.AlgorithmSpecification != nil {
-		if ko.Spec.AlgorithmSpecification.MetricDefinitions == nil {
-			return true
-		}
-	}
 	if ko.Spec.EnableInterContainerTrafficEncryption == nil {
 		return true
 	}
@@ -287,11 +282,6 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	if observedKo.Spec.AlgorithmSpecification != nil && latestKo.Spec.AlgorithmSpecification != nil {
 		if observedKo.Spec.AlgorithmSpecification.EnableSageMakerMetricsTimeSeries != nil && latestKo.Spec.AlgorithmSpecification.EnableSageMakerMetricsTimeSeries == nil {
 			latestKo.Spec.AlgorithmSpecification.EnableSageMakerMetricsTimeSeries = observedKo.Spec.AlgorithmSpecification.EnableSageMakerMetricsTimeSeries
-		}
-	}
-	if observedKo.Spec.AlgorithmSpecification != nil && latestKo.Spec.AlgorithmSpecification != nil {
-		if observedKo.Spec.AlgorithmSpecification.MetricDefinitions != nil && latestKo.Spec.AlgorithmSpecification.MetricDefinitions == nil {
-			latestKo.Spec.AlgorithmSpecification.MetricDefinitions = observedKo.Spec.AlgorithmSpecification.MetricDefinitions
 		}
 	}
 	if observedKo.Spec.EnableInterContainerTrafficEncryption != nil && latestKo.Spec.EnableInterContainerTrafficEncryption == nil {


### PR DESCRIPTION
Issue #, if available:
When a distributed/parallelized pytorch workload is run, AlgorithmSpecification.MetricDefinitions does not late initialize which makes the controller re queue for a long time. 

Description of changes:
Edited generator.yaml to remove late_initialize and to ignore comparisons(ACK trainingjob does not support update operations so this wont effect the user). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
