### PR TITLE
Handle server side default for inputDataConfig in TrainingJob

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,7 +1,7 @@
 ack_generate_info:
-  build_date: "2022-08-17T23:24:33Z"
+  build_date: "2022-08-18T06:59:27Z"
   build_hash: fe61d04673fd4d9848d5f726b01e0689a16d3733
-  go_version: go1.17.1
+  go_version: go1.17.13
   version: v0.19.3-1-gfe61d04
 api_directory_checksum: 8b3c128d2037d5227679cccb57cd4d78af6aed1b
 api_version: v1alpha1

--- a/pkg/resource/training_job/custom_delta.go
+++ b/pkg/resource/training_job/custom_delta.go
@@ -15,6 +15,7 @@ package training_job
 
 import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	svcapitypes "github.com/aws-controllers-k8s/sagemaker-controller/apis/v1alpha1"
 	"github.com/aws/aws-sdk-go/aws"
 )
 
@@ -45,6 +46,11 @@ func customSetDefaults(
 
 	// Default value of RecordWrapperType is None
 	defaultRecordWrapperType := aws.String("None")
+
+	// inputDataConfig is an optional field. Its default value is an empty list
+	if ackcompare.IsNil(a.ko.Spec.InputDataConfig) && ackcompare.IsNotNil(b.ko.Spec.InputDataConfig) {
+		a.ko.Spec.InputDataConfig = []*svcapitypes.Channel{}
+	}
 
 	if ackcompare.IsNotNil(a.ko.Spec.InputDataConfig) && ackcompare.IsNotNil(b.ko.Spec.InputDataConfig) {
 		for index := range a.ko.Spec.InputDataConfig {


### PR DESCRIPTION
Bug fix for unhandled case in training job. `inputDataConfig` is an optional field. Its default value is an empty list. Without this hook, the controller reconciles because of diff between null(desired) and empty list(observed) when `inputDataConfig` is not specified
  - usecase: If user bundles the dataset and training code into the training image or downloads dataset at runtime

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
