### PR TITLE
check in status for lastModifiedTime pipelineResources

### DIFF
--- a/test/e2e/tests/test_pipeline.py
+++ b/test/e2e/tests/test_pipeline.py
@@ -156,7 +156,7 @@ class TestPipeline:
         )
         assert old_pipeline_last_modified_time != pipeline_desc["LastModifiedTime"]
         assert (
-            resource["spec"].get("lastModifiedTime", None)
+            resource["status"].get("lastModifiedTime")
             != old_pipeline_last_modified_time
         )
 

--- a/test/e2e/tests/test_pipeline_execution.py
+++ b/test/e2e/tests/test_pipeline_execution.py
@@ -177,7 +177,7 @@ class TestPipelineExecution:
             )
 
         old_pipeline_last_modified_time = pipeline_execution_desc["LastModifiedTime"]
-
+    
         assert k8s.get_resource_arn(resource) == pipeline_execution_arn
 
         self._assert_pipeline_execution_status_in_sync(
@@ -220,7 +220,7 @@ class TestPipelineExecution:
             != pipeline_execution_desc["LastModifiedTime"]
         )
         assert (
-            resource["spec"].get("lastModifiedTime", None)
+            resource["status"].get("lastModifiedTime")
             != old_pipeline_last_modified_time
         )
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Check status field for lastModifiedtime in K8S side check


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
