### PR TITLE
Update to ACK runtime v0.21.0, code-generator v0.21.0

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2022-12-09T19:03:55Z"
-  build_hash: 6e2ffbc3b16a30ac59be6719918c601c2c864064
+  build_date: "2022-12-15T02:28:45Z"
+  build_hash: 12246c7da82841b351ec7a9e1f139f9338f2784b
   go_version: go1.17.13
-  version: v0.20.1-3-g6e2ffbc
+  version: v0.21.0
 api_directory_checksum: 48886052888c7166740636bc128afdb53d05a4cb
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.117

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/sagemaker-controller
 go 1.17
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.20.1
+	github.com/aws-controllers-k8s/runtime v0.21.0
 	github.com/aws/aws-sdk-go v1.44.117
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.20.1 h1:L/Huf1shRahx5BqJBCSS5u+vYg3f0Rotsq1jutORpdI=
-github.com/aws-controllers-k8s/runtime v0.20.1/go.mod h1:k7z4qlf6aK1Kzd4ff49wzcyhDKHjWaUpqxrwgl4uS1o=
+github.com/aws-controllers-k8s/runtime v0.21.0 h1:e9DK88QodwXMLz+QXPXk+8XNetVj4ij+puaVwn9uEVc=
+github.com/aws-controllers-k8s/runtime v0.21.0/go.mod h1:k7z4qlf6aK1Kzd4ff49wzcyhDKHjWaUpqxrwgl4uS1o=
 github.com/aws/aws-sdk-go v1.44.93/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.44.117 h1:mZuODB3Y4soG9QWAXyGb2po+6Easa/enifpj4MnZ91s=
 github.com/aws/aws-sdk-go v1.44.117/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
@@ -151,7 +151,7 @@ github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
-github.com/go-logfmt/logfmt v0.5.0-rc.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
@@ -216,7 +216,7 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.0-rc.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -270,7 +270,7 @@ github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdv
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
-github.com/hashicorp/golang-lru v0.5.0-rc.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/pkg/resource/app/tags.go
+++ b/pkg/resource/app/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/data_quality_job_definition/tags.go
+++ b/pkg/resource/data_quality_job_definition/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/domain/tags.go
+++ b/pkg/resource/domain/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/endpoint/tags.go
+++ b/pkg/resource/endpoint/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/endpoint_config/tags.go
+++ b/pkg/resource/endpoint_config/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/feature_group/tags.go
+++ b/pkg/resource/feature_group/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/hyper_parameter_tuning_job/tags.go
+++ b/pkg/resource/hyper_parameter_tuning_job/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/model/tags.go
+++ b/pkg/resource/model/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/model_bias_job_definition/tags.go
+++ b/pkg/resource/model_bias_job_definition/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/model_explainability_job_definition/tags.go
+++ b/pkg/resource/model_explainability_job_definition/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/model_package_group/tags.go
+++ b/pkg/resource/model_package_group/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/model_quality_job_definition/tags.go
+++ b/pkg/resource/model_quality_job_definition/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/monitoring_schedule/tags.go
+++ b/pkg/resource/monitoring_schedule/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/notebook_instance/tags.go
+++ b/pkg/resource/notebook_instance/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/pipeline/tags.go
+++ b/pkg/resource/pipeline/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/processing_job/tags.go
+++ b/pkg/resource/processing_job/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/training_job/tags.go
+++ b/pkg/resource/training_job/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/transform_job/tags.go
+++ b/pkg/resource/transform_job/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 

--- a/pkg/resource/user_profile/tags.go
+++ b/pkg/resource/user_profile/tags.go
@@ -36,10 +36,12 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	}
 
 	for _, t := range tags {
-		if t.Value == nil {
-			result[*t.Key] = ""
-		} else {
-			result[*t.Key] = *t.Value
+		if t.Key != nil {
+			if t.Value == nil {
+				result[*t.Key] = ""
+			} else {
+				result[*t.Key] = *t.Value
+			}
 		}
 	}
 


### PR DESCRIPTION
Issue #, if available:
- [#1586](https://github.com/aws-controllers-k8s/community/issues/1586)
- [#1549](https://github.com/aws-controllers-k8s/community/issues/1549)

Description of changes:
- Use code generator version v0.21.0 to avoid tag bug
- Upgraded runtime to v0.21.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
