### PR TITLE
fix: late initialize volumeInSizeGB field

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2023-01-10T19:11:16Z"
+  build_date: "2023-01-12T17:32:55Z"
   build_hash: 12246c7da82841b351ec7a9e1f139f9338f2784b
   go_version: go1.17.13
   version: v0.21.0
@@ -7,7 +7,7 @@ api_directory_checksum: 48886052888c7166740636bc128afdb53d05a4cb
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.117
 generator_config_info:
-  file_checksum: 1c2565c8be351e2db5832b707691a43bf3d38555
+  file_checksum: 0dbded7103f1cdd041678e22ac0fffcc6ec12ff1
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -688,7 +688,10 @@ resources:
           path: FailureReason
       Tags:
         compare:
-          is_ignored: true        
+          is_ignored: true
+      VolumeSizeInGB:
+        late_initialize:
+          min_backoff_seconds: 5        
   ModelPackageGroup:
       exceptions:
         errors:

--- a/generator.yaml
+++ b/generator.yaml
@@ -688,7 +688,10 @@ resources:
           path: FailureReason
       Tags:
         compare:
-          is_ignored: true        
+          is_ignored: true
+      VolumeSizeInGB:
+        late_initialize:
+          min_backoff_seconds: 5        
   ModelPackageGroup:
       exceptions:
         errors:

--- a/pkg/resource/notebook_instance/manager.go
+++ b/pkg/resource/notebook_instance/manager.go
@@ -51,7 +51,7 @@ var (
 // +kubebuilder:rbac:groups=sagemaker.services.k8s.aws,resources=notebookinstances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=sagemaker.services.k8s.aws,resources=notebookinstances/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"PlatformIdentifier"}
+var lateInitializeFieldNames = []string{"PlatformIdentifier", "VolumeSizeInGB"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -252,6 +252,9 @@ func (rm *resourceManager) incompleteLateInitialization(
 	if ko.Spec.PlatformIdentifier == nil {
 		return true
 	}
+	if ko.Spec.VolumeSizeInGB == nil {
+		return true
+	}
 	return false
 }
 
@@ -265,6 +268,9 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	latestKo := rm.concreteResource(latest).ko.DeepCopy()
 	if observedKo.Spec.PlatformIdentifier != nil && latestKo.Spec.PlatformIdentifier == nil {
 		latestKo.Spec.PlatformIdentifier = observedKo.Spec.PlatformIdentifier
+	}
+	if observedKo.Spec.VolumeSizeInGB != nil && latestKo.Spec.VolumeSizeInGB == nil {
+		latestKo.Spec.VolumeSizeInGB = observedKo.Spec.VolumeSizeInGB
 	}
 	return &resource{latestKo}
 }


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/1628

Description of changes:
Adds volumeInSizeGB as a late initialized field in NotebookInstance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
