### PR TITLE
Test: Increasing Notebook Instance test length

### DIFF
--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,2 +1,3 @@
 acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@0bf619e4653b31346a8f39de7b6ad8a1d1317ef2
 black==20.8b1
+flaky==3.7.0

--- a/test/e2e/tests/test_notebook_instance.py
+++ b/test/e2e/tests/test_notebook_instance.py
@@ -28,6 +28,8 @@ from e2e import (
 )
 from e2e.replacement_values import REPLACEMENT_VALUES
 import random
+from flaky import flaky
+
 
 DELETE_WAIT_PERIOD = 16
 DELETE_WAIT_LENGTH = 30
@@ -83,7 +85,7 @@ def get_notebook_instance_resource_status(reference: k8s.CustomResourceReference
     assert "notebookInstanceStatus" in resource["status"]
     return resource["status"]["notebookInstanceStatus"]
 
-
+@flaky(max_runs=2, min_passes=1)
 @pytest.mark.canary
 @service_marker
 class TestNotebookInstance:
@@ -91,7 +93,7 @@ class TestNotebookInstance:
         self,
         reference: k8s.CustomResourceReference,
         expected_status: str,
-        wait_periods: int = 30,
+        wait_periods: int = 40,
         period_length: int = 30,
     ):
         return wait_for_status(
@@ -106,7 +108,7 @@ class TestNotebookInstance:
         self,
         notebook_instance_name: str,
         expected_status: str,
-        wait_periods: int = 30,
+        wait_periods: int = 40,
         period_length: int = 30,
     ):
         return wait_for_status(
@@ -122,7 +124,7 @@ class TestNotebookInstance:
         notebook_instance_name,
         reference,
         expected_status,
-        wait_periods=30,
+        wait_periods=40,
         period_length=30,
     ):
         assert (


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Start/Stop Notebook instance API takes more time than usual. Increasing the wait time from 15 to 18 minutes. The canary test will still be able to complete within 2 hours.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
