### PR TITLE
Run Notebook test in specified regions

### DIFF
--- a/test/canary/scripts/run_test.sh
+++ b/test/canary/scripts/run_test.sh
@@ -85,5 +85,9 @@ pushd $E2E_DIR
 
   # run tests
   echo "Run Tests"
-  pytest -n 15 --dist loadfile --log-cli-level INFO -m canary
+   if [[ $SERVICE_REGION =~ ^(us-west-2)$ ]]; then
+    pytest -n 15 --dist loadfile --log-cli-level INFO -m "small_region"
+  else
+    echo "SERVICE_REGION is not in the list of allowed regions for small-region tests. Skipping pytest."
+  fi
 popd

--- a/test/canary/scripts/run_test.sh
+++ b/test/canary/scripts/run_test.sh
@@ -85,9 +85,9 @@ pushd $E2E_DIR
 
   # run tests
   echo "Run Tests"
-   if [[ $SERVICE_REGION =~ ^(sa-east-1|us-west-2|eu-north-1|eu-west-3)$  ]]; then
+   if [[ $SERVICE_REGION =~ ^(sa-east-1|eu-north-1|eu-west-3)$  ]]; then
     pytest -n 15 --dist loadfile --log-cli-level INFO -m "canary or small_region"
   else
-    echo "SERVICE_REGION is not in the list of allowed regions for small-region tests. Skipping pytest."
+    pytest -n 15 --dist loadfile --log-cli-level INFO -m "canary"
   fi
 popd

--- a/test/canary/scripts/run_test.sh
+++ b/test/canary/scripts/run_test.sh
@@ -48,6 +48,8 @@ function cleanup {
   kubectl delete modelpackagegroups --all
   kubectl delete notebookinstances --all
   kubectl delete notebookinstancelifecycleconfig --all
+  kubectl delete pipelineexecutions --all
+  kubectl delete pipelines --all
 
   print_controller_logs
 

--- a/test/canary/scripts/run_test.sh
+++ b/test/canary/scripts/run_test.sh
@@ -87,10 +87,12 @@ pushd $E2E_DIR
 
   # run tests
   echo "Run Tests"
+  pytest_args=( -n 15 --dist loadfile --log-cli-level INFO )
   if [[ $SERVICE_REGION =~ ^(eu-north-1|eu-west-3)$  ]]; then
     # If select_regions_1 true we run the notebook_instance test
-    pytest -n 15 --dist loadfile --log-cli-level INFO -m "canary or select_regions_1"
+    pytest_args+=(-m "canary or select_regions_1")
   else
-    pytest -n 15 --dist loadfile --log-cli-level INFO -m "canary"
+    pytest_args+=(-m "canary")
+  pytest "${pytest_args[@]}"
   fi
 popd

--- a/test/canary/scripts/run_test.sh
+++ b/test/canary/scripts/run_test.sh
@@ -88,7 +88,8 @@ pushd $E2E_DIR
   # run tests
   echo "Run Tests"
   if [[ $SERVICE_REGION =~ ^(sa-east-1|eu-north-1|eu-west-3)$  ]]; then
-    pytest -n 15 --dist loadfile --log-cli-level INFO -m "canary or small_region"
+    # If select_regions_1 true we run the notebook_instance test
+    pytest -n 15 --dist loadfile --log-cli-level INFO -m "canary or select_regions_1"
   else
     pytest -n 15 --dist loadfile --log-cli-level INFO -m "canary"
   fi

--- a/test/canary/scripts/run_test.sh
+++ b/test/canary/scripts/run_test.sh
@@ -85,8 +85,8 @@ pushd $E2E_DIR
 
   # run tests
   echo "Run Tests"
-   if [[ $SERVICE_REGION =~ ^(us-west-2)$ ]]; then
-    pytest -n 15 --dist loadfile --log-cli-level INFO -m "small_region"
+   if [[ $SERVICE_REGION =~ ^(sa-east-1|us-west-2|eu-north-1|eu-west-3)$  ]]; then
+    pytest -n 15 --dist loadfile --log-cli-level INFO -m "canary or small_region"
   else
     echo "SERVICE_REGION is not in the list of allowed regions for small-region tests. Skipping pytest."
   fi

--- a/test/canary/scripts/run_test.sh
+++ b/test/canary/scripts/run_test.sh
@@ -85,7 +85,7 @@ pushd $E2E_DIR
 
   # run tests
   echo "Run Tests"
-   if [[ $SERVICE_REGION =~ ^(sa-east-1|eu-north-1|eu-west-3)$  ]]; then
+  if [[ $SERVICE_REGION =~ ^(sa-east-1|eu-north-1|eu-west-3)$  ]]; then
     pytest -n 15 --dist loadfile --log-cli-level INFO -m "canary or small_region"
   else
     pytest -n 15 --dist loadfile --log-cli-level INFO -m "canary"

--- a/test/canary/scripts/run_test.sh
+++ b/test/canary/scripts/run_test.sh
@@ -87,7 +87,7 @@ pushd $E2E_DIR
 
   # run tests
   echo "Run Tests"
-  if [[ $SERVICE_REGION =~ ^(sa-east-1|eu-north-1|eu-west-3)$  ]]; then
+  if [[ $SERVICE_REGION =~ ^(eu-north-1|eu-west-3)$  ]]; then
     # If select_regions_1 true we run the notebook_instance test
     pytest -n 15 --dist loadfile --log-cli-level INFO -m "canary or select_regions_1"
   else

--- a/test/e2e/tests/test_notebook_instance.py
+++ b/test/e2e/tests/test_notebook_instance.py
@@ -86,7 +86,7 @@ def get_notebook_instance_resource_status(reference: k8s.CustomResourceReference
     return resource["status"]["notebookInstanceStatus"]
 
 @flaky(max_runs=2, min_passes=1)
-@pytest.mark.canary
+@pytest.mark.small_region
 @service_marker
 class TestNotebookInstance:
     def _wait_resource_notebook_status(

--- a/test/e2e/tests/test_notebook_instance.py
+++ b/test/e2e/tests/test_notebook_instance.py
@@ -86,7 +86,7 @@ def get_notebook_instance_resource_status(reference: k8s.CustomResourceReference
     return resource["status"]["notebookInstanceStatus"]
 
 @flaky(max_runs=2, min_passes=1)
-@pytest.mark.small_region
+@pytest.mark.select_regions_1
 @service_marker
 class TestNotebookInstance:
     def _wait_resource_notebook_status(


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Notebook instance test is quite flakey due to long start times in popular regions, increasing the timeout several times does not seem to be the solution. Instead only running this test in regions that the notebook team indicate are faster to spin up
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
