### PR TITLE
Fix delete_custom_resource import

### DIFF
--- a/test/e2e/__init__.py
+++ b/test/e2e/__init__.py
@@ -23,7 +23,7 @@ from unittest import TestCase
 import random
 
 from acktest.k8s import resource as k8s
-from common import config as cfg
+from e2e.common import config as cfg
 
 
 SERVICE_NAME = "sagemaker"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Previous import did not work when run in same-level 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
