### PR TITLE
Increase wait period in test for sagemaker resource

### DIFF
--- a/test/e2e/__init__.py
+++ b/test/e2e/__init__.py
@@ -49,7 +49,7 @@ def create_sagemaker_resource(
     spec_file,
     replacements,
     namespace="default",
-    wait_period=3,
+    wait_period=6,
     period_length=10,
 ):
     """


### PR DESCRIPTION
Increase wait perior to fix the error that some sagemaker resources are not ready

```
        model_reference, model_spec, model_resource = create_sagemaker_resource(
            resource_plural=cfg.MODEL_RESOURCE_PLURAL,
            resource_name=model_resource_name,
            spec_file="xgboost_model_with_model_location",
            replacements=replacements,
        )
>       assert model_resource is not None
E       AssertionError
```
