### PR TITLE
Add select_regions_1 as config and unindent pytest command

### DIFF
--- a/test/canary/scripts/run_test.sh
+++ b/test/canary/scripts/run_test.sh
@@ -93,6 +93,6 @@ pushd $E2E_DIR
     pytest_args+=(-m "canary or select_regions_1")
   else
     pytest_args+=(-m "canary")
-  pytest "${pytest_args[@]}"
   fi
+  pytest "${pytest_args[@]}"
 popd

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -29,6 +29,7 @@ def pytest_configure(config):
         "markers", "service(arg): mark test associated with a given service"
     )
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers", "select_regions_1: mark test to only run if in select region")
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Later refactor to this code, had incorrect indent which causes tests to not run when the ifstatement is true.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
