### PR TITLE
Cherry-picks Update to ACK runtime `v0.25.0`, code-generator `v0.25.0` (#220) 

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2023-03-16T21:08:36Z"
-  build_hash: 910a8e0744a99c5c87d8c1615926985215a60d8c
+  build_date: "2023-03-22T22:11:35Z"
+  build_hash: fa24753ea8b657d8815ae3eac7accd0958f5f9fb
   go_version: go1.19
-  version: v0.24.3
+  version: v0.25.0
 api_directory_checksum: 62a1b01c505efd55545d306c2353b9673ce344fb
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.218

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/sagemaker-controller
-  newTag: v1.2.0
+  newTag: v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/sagemaker-controller
 go 1.19
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.24.1
+	github.com/aws-controllers-k8s/runtime v0.25.0
 	github.com/aws/aws-sdk-go v1.44.218
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/aws-controllers-k8s/runtime v0.24.1 h1:vmOWKlo4oPtPxeofRnd/dA49WR5VZSqSxHiSiNTiknY=
-github.com/aws-controllers-k8s/runtime v0.24.1/go.mod h1:jizDzKikL09cueIuA9ZxoZ+4pfn5U7oKW5s/ZAqOA6E=
+github.com/aws-controllers-k8s/runtime v0.25.0 h1:6SYa8qmbw+Yil5/LodF7LmIGxBhpjz4QEIvNjpeRuoc=
+github.com/aws-controllers-k8s/runtime v0.25.0/go.mod h1:jizDzKikL09cueIuA9ZxoZ+4pfn5U7oKW5s/ZAqOA6E=
 github.com/aws/aws-sdk-go v1.44.218 h1:p707+xOCazWhkSpZOeyhtTcg7Z+asxxvueGgYPSitn4=
 github.com/aws/aws-sdk-go v1.44.218/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: sagemaker-chart
 description: A Helm chart for the ACK service controller for Amazon SageMaker (SageMaker)
-version: v1.2.0
-appVersion: v1.2.0
+version: v1.2.1
+appVersion: v1.2.1
 home: https://github.com/aws-controllers-k8s/sagemaker-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/sagemaker-controller:v1.2.0".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/sagemaker-controller:v1.2.1".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/sagemaker-controller
-  tag: v1.2.0
+  tag: v1.2.1
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/pkg/resource/app/descriptor.go
+++ b/pkg/resource/app/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/data_quality_job_definition/descriptor.go
+++ b/pkg/resource/data_quality_job_definition/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/domain/descriptor.go
+++ b/pkg/resource/domain/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/endpoint/descriptor.go
+++ b/pkg/resource/endpoint/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/endpoint_config/descriptor.go
+++ b/pkg/resource/endpoint_config/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/feature_group/descriptor.go
+++ b/pkg/resource/feature_group/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/hyper_parameter_tuning_job/descriptor.go
+++ b/pkg/resource/hyper_parameter_tuning_job/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/model/descriptor.go
+++ b/pkg/resource/model/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/model_bias_job_definition/descriptor.go
+++ b/pkg/resource/model_bias_job_definition/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/model_explainability_job_definition/descriptor.go
+++ b/pkg/resource/model_explainability_job_definition/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/model_package/descriptor.go
+++ b/pkg/resource/model_package/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/model_package_group/descriptor.go
+++ b/pkg/resource/model_package_group/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/model_quality_job_definition/descriptor.go
+++ b/pkg/resource/model_quality_job_definition/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/monitoring_schedule/descriptor.go
+++ b/pkg/resource/monitoring_schedule/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/notebook_instance/descriptor.go
+++ b/pkg/resource/notebook_instance/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/notebook_instance_lifecycle_config/descriptor.go
+++ b/pkg/resource/notebook_instance_lifecycle_config/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/pipeline/descriptor.go
+++ b/pkg/resource/pipeline/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/pipeline_execution/descriptor.go
+++ b/pkg/resource/pipeline_execution/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/processing_job/descriptor.go
+++ b/pkg/resource/processing_job/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/training_job/descriptor.go
+++ b/pkg/resource/training_job/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/transform_job/descriptor.go
+++ b/pkg/resource/transform_job/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in

--- a/pkg/resource/user_profile/descriptor.go
+++ b/pkg/resource/user_profile/descriptor.go
@@ -20,6 +20,7 @@ import (
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -43,10 +44,10 @@ var (
 type resourceDescriptor struct {
 }
 
-// GroupKind returns a Kubernetes metav1.GroupKind struct that describes the
-// API Group and Kind of CRs described by the descriptor
-func (d *resourceDescriptor) GroupKind() *metav1.GroupKind {
-	return &GroupKind
+// GroupVersionKind returns a Kubernetes schema.GroupVersionKind struct that
+// describes the API Group, Version and Kind of CRs described by the descriptor
+func (d *resourceDescriptor) GroupVersionKind() schema.GroupVersionKind {
+	return svcapitypes.GroupVersion.WithKind(GroupKind.Kind)
 }
 
 // EmptyRuntimeObject returns an empty object prototype that may be used in


### PR DESCRIPTION
### Update to ACK runtime `v0.25.0`, code-generator `v0.25.0`

Latest tag is v1.2.1 which was created automatically after te update to ACK runtime and codegen was merged, should cherry-pick this to the release branch so that we are testing the latest.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
