### PR TITLE
[Cherry-pick] Create shallow canary marker and fix "No S3 objects found under S3"

### DIFF
--- a/test/canary/scripts/run_test.sh
+++ b/test/canary/scripts/run_test.sh
@@ -97,6 +97,8 @@ pushd $E2E_DIR
   if [[ $SERVICE_REGION =~ ^(eu-north-1|eu-west-3)$  ]]; then
     # If select_regions_1 true we run the notebook_instance test
     pytest_args+=(-m "canary or select_regions_1")
+  elif [[ $SERVICE_REGION =~ ^(eu-south-2|ap-southeast-3|me-central-1|eu-central-2)$  ]]; then
+    pytest_args+=(-m "shallow_canary")
   else
     pytest_args+=(-m "canary")
   fi

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -30,6 +30,7 @@ def pytest_configure(config):
     )
     config.addinivalue_line("markers", "slow: mark test as slow to run")
     config.addinivalue_line("markers", "select_regions_1: mark test to only run if in select region")
+    config.addinivalue_line("markers", "shallow_canary: mark test to run in shallow canary tests")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/test/e2e/replacement_values.py
+++ b/test/e2e/replacement_values.py
@@ -18,6 +18,7 @@ from acktest.aws.identity import get_region
 from e2e.bootstrap_resources import get_bootstrap_resources
 
 # Taken from the SageMaker Python SDK
+# https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/image_uri_config/xgboost.json
 # Rather than including the entire SDK
 XGBOOST_IMAGE_URIS = {
     "us-west-1": "746614075791.dkr.ecr.us-west-1.amazonaws.com",
@@ -40,8 +41,15 @@ XGBOOST_IMAGE_URIS = {
     "eu-west-3": "659782779980.dkr.ecr.eu-west-3.amazonaws.com",
     "me-south-1": "801668240914.dkr.ecr.me-south-1.amazonaws.com",
     "sa-east-1": "737474898029.dkr.ecr.sa-east-1.amazonaws.com",
+    "eu-south-1": "978288397137.dkr.ecr.eu-south-1.amazonaws.com",
+    "ap-northeast-3": "867004704886.dkr.ecr.ap-northeast-3.amazonaws.com",
+    "eu-south-2": "104374241257.dkr.ecr.eu-south-2.amazonaws.com",
+    "ap-southeast-3": "951798379941.dkr.ecr.ap-southeast-3.amazonaws.com",
+    "me-central-1": "272398656194.dkr.ecr.me-central-1.amazonaws.com",
+    "eu-central-2": "680994064768.dkr.ecr.eu-central-2.amazonaws.com",
 }
 
+# https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/image_uri_config/debugger.json
 DEBUGGER_IMAGE_URIS = {
     "us-west-1": "685455198987.dkr.ecr.us-west-1.amazonaws.com",
     "us-west-2": "895741380848.dkr.ecr.us-west-2.amazonaws.com",
@@ -63,6 +71,8 @@ DEBUGGER_IMAGE_URIS = {
     "eu-west-3": "447278800020.dkr.ecr.eu-west-3.amazonaws.com",
     "me-south-1": "986000313247.dkr.ecr.me-south-1.amazonaws.com",
     "sa-east-1": "818342061345.dkr.ecr.sa-east-1.amazonaws.com",
+    "eu-south-1": "563282790590.dkr.ecr.eu-south-1.amazonaws.com",
+    "ap-northeast-3": "479947661362.dkr.ecr.ap-northeast-3.amazonaws.com",
 }
 
 # https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
@@ -87,6 +97,12 @@ XGBOOST_V1_IMAGE_URIS = {
     "eu-west-3": "749696950732.dkr.ecr.eu-west-3.amazonaws.com",
     "me-south-1": "249704162688.dkr.ecr.me-south-1.amazonaws.com",
     "sa-east-1": "855470959533.dkr.ecr.sa-east-1.amazonaws.com",
+    "eu-south-1": "257386234256.dkr.ecr.eu-south-1.amazonaws.com", 
+    "ap-northeast-3": "867004704886.dkr.ecr.ap-northeast-3.amazonaws.com",
+    "eu-south-2": "104374241257.dkr.ecr.eu-south-2.amazonaws.com",
+    "ap-southeast-3": "951798379941.dkr.ecr.ap-southeast-3.amazonaws.com",
+    "me-central-1": "272398656194.dkr.ecr.me-central-1.amazonaws.com",
+    "eu-central-2": "680994064768.dkr.ecr.eu-central-2.amazonaws.com",
 }
 
 
@@ -113,6 +129,11 @@ PYTORCH_TRAIN_IMAGE_URIS = {
     "sa-east-1": "763104351884.dkr.ecr.sa-east-1.amazonaws.com",
     "cn-north-1": "727897471807.dkr.ecr.cn-north-1.amazonaws.com.cn",
     "cn-northwest-1": "727897471807.dkr.ecr.cn-northwest-1.amazonaws.com.cn",
+    "ap-northeast-3": "364406365360.dkr.ecr.ap-northeast-3.amazonaws.com",    
+    "eu-south-2": "503227376785.dkr.ecr.eu-south-2.amazonaws.com",
+    "ap-southeast-3": "907027046896.dkr.ecr.ap-southeast-3.amazonaws.com",
+    "me-central-1": "914824155844.dkr.ecr.me-central-1.amazonaws.com",
+    "eu-central-2": "380420809688.dkr.ecr.eu-central-2.amazonaws.com",
 }
 
 # https://docs.aws.amazon.com/sagemaker/latest/dg/model-monitor-pre-built-container.html
@@ -140,6 +161,8 @@ MODEL_MONITOR_IMAGE_URIS = {
     "me-south-1": "607024016150.dkr.ecr.me-south-1.amazonaws.com",
     "sa-east-1": "539772159869.dkr.ecr.sa-east-1.amazonaws.com",
     "us-gov-west-1": "362178532790.dkr.ecr.us-gov-west-1.amazonaws.com",
+    "ap-northeast-3": "990339680094.dkr.ecr.ap-northeast-3.amazonaws.com",
+    "ap-southeast-3": "669540362728.dkr.ecr.ap-southeast-3.amazonaws.com",
 }
 
 # https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html#clarify-processing-job-configure-container
@@ -164,6 +187,8 @@ CLARIFY_IMAGE_URIS = {
     "sa-east-1": "520018980103.dkr.ecr.sa-east-1.amazonaws.com",
     "af-south-1": "811711786498.dkr.ecr.af-south-1.amazonaws.com",
     "eu-south-1": "638885417683.dkr.ecr.eu-south-1.amazonaws.com",
+    "ap-northeast-3": "912233562940.dkr.ecr.ap-northeast-3.amazonaws.com",
+    "ap-southeast-3": "705930551576.dkr.ecr.ap-southeast-3.amazonaws.com",
 }
 
 ENDPOINT_INSTANCE_TYPES = {
@@ -174,6 +199,7 @@ ENDPOINT_INSTANCE_TYPES = {
 TRAINING_JOB_INSTANCE_TYPES = {
     "eu-west-3": "ml.m5.xlarge",
     "eu-north-1": "ml.m5.xlarge",
+    "me-south-1": "ml.m5.xlarge",
 }
 
 NOTEBOOK_INSTANCE_INSTANCE_TYPES = {

--- a/test/e2e/replacement_values.py
+++ b/test/e2e/replacement_values.py
@@ -47,6 +47,7 @@ XGBOOST_IMAGE_URIS = {
     "ap-southeast-3": "951798379941.dkr.ecr.ap-southeast-3.amazonaws.com",
     "me-central-1": "272398656194.dkr.ecr.me-central-1.amazonaws.com",
     "eu-central-2": "680994064768.dkr.ecr.eu-central-2.amazonaws.com",
+    "af-south-1": "510948584623.dkr.ecr.af-south-1.amazonaws.com",
 }
 
 # https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/image_uri_config/debugger.json
@@ -73,6 +74,11 @@ DEBUGGER_IMAGE_URIS = {
     "sa-east-1": "818342061345.dkr.ecr.sa-east-1.amazonaws.com",
     "eu-south-1": "563282790590.dkr.ecr.eu-south-1.amazonaws.com",
     "ap-northeast-3": "479947661362.dkr.ecr.ap-northeast-3.amazonaws.com",
+    "af-south-1": "314341159256.dkr.ecr.af-south-1.amazonaws.com",
+    "eu-south-2": "",
+    "ap-southeast-3": "",
+    "me-central-1": "",
+    "eu-central-2": "",
 }
 
 # https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
@@ -103,6 +109,7 @@ XGBOOST_V1_IMAGE_URIS = {
     "ap-southeast-3": "951798379941.dkr.ecr.ap-southeast-3.amazonaws.com",
     "me-central-1": "272398656194.dkr.ecr.me-central-1.amazonaws.com",
     "eu-central-2": "680994064768.dkr.ecr.eu-central-2.amazonaws.com",
+    "af-south-1": "455444449433.dkr.ecr.af-south-1.amazonaws.com",
 }
 
 
@@ -163,6 +170,9 @@ MODEL_MONITOR_IMAGE_URIS = {
     "us-gov-west-1": "362178532790.dkr.ecr.us-gov-west-1.amazonaws.com",
     "ap-northeast-3": "990339680094.dkr.ecr.ap-northeast-3.amazonaws.com",
     "ap-southeast-3": "669540362728.dkr.ecr.ap-southeast-3.amazonaws.com",
+    "eu-south-2": "",
+    "me-central-1": "",
+    "eu-central-2": "",
 }
 
 # https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html#clarify-processing-job-configure-container
@@ -189,6 +199,9 @@ CLARIFY_IMAGE_URIS = {
     "eu-south-1": "638885417683.dkr.ecr.eu-south-1.amazonaws.com",
     "ap-northeast-3": "912233562940.dkr.ecr.ap-northeast-3.amazonaws.com",
     "ap-southeast-3": "705930551576.dkr.ecr.ap-southeast-3.amazonaws.com",
+    "eu-south-2": "",
+    "me-central-1": "",
+    "eu-central-2": "",
 }
 
 ENDPOINT_INSTANCE_TYPES = {

--- a/test/e2e/replacement_values.py
+++ b/test/e2e/replacement_values.py
@@ -75,10 +75,6 @@ DEBUGGER_IMAGE_URIS = {
     "eu-south-1": "563282790590.dkr.ecr.eu-south-1.amazonaws.com",
     "ap-northeast-3": "479947661362.dkr.ecr.ap-northeast-3.amazonaws.com",
     "af-south-1": "314341159256.dkr.ecr.af-south-1.amazonaws.com",
-    "eu-south-2": "",
-    "ap-southeast-3": "",
-    "me-central-1": "",
-    "eu-central-2": "",
 }
 
 # https://docs.aws.amazon.com/sagemaker/latest/dg/sagemaker-algo-docker-registry-paths.html
@@ -136,7 +132,7 @@ PYTORCH_TRAIN_IMAGE_URIS = {
     "sa-east-1": "763104351884.dkr.ecr.sa-east-1.amazonaws.com",
     "cn-north-1": "727897471807.dkr.ecr.cn-north-1.amazonaws.com.cn",
     "cn-northwest-1": "727897471807.dkr.ecr.cn-northwest-1.amazonaws.com.cn",
-    "ap-northeast-3": "364406365360.dkr.ecr.ap-northeast-3.amazonaws.com",    
+    "ap-northeast-3": "364406365360.dkr.ecr.ap-northeast-3.amazonaws.com",
     "eu-south-2": "503227376785.dkr.ecr.eu-south-2.amazonaws.com",
     "ap-southeast-3": "907027046896.dkr.ecr.ap-southeast-3.amazonaws.com",
     "me-central-1": "914824155844.dkr.ecr.me-central-1.amazonaws.com",
@@ -170,9 +166,6 @@ MODEL_MONITOR_IMAGE_URIS = {
     "us-gov-west-1": "362178532790.dkr.ecr.us-gov-west-1.amazonaws.com",
     "ap-northeast-3": "990339680094.dkr.ecr.ap-northeast-3.amazonaws.com",
     "ap-southeast-3": "669540362728.dkr.ecr.ap-southeast-3.amazonaws.com",
-    "eu-south-2": "",
-    "me-central-1": "",
-    "eu-central-2": "",
 }
 
 # https://docs.aws.amazon.com/sagemaker/latest/dg/clarify-configure-processing-jobs.html#clarify-processing-job-configure-container
@@ -199,9 +192,6 @@ CLARIFY_IMAGE_URIS = {
     "eu-south-1": "638885417683.dkr.ecr.eu-south-1.amazonaws.com",
     "ap-northeast-3": "912233562940.dkr.ecr.ap-northeast-3.amazonaws.com",
     "ap-southeast-3": "705930551576.dkr.ecr.ap-southeast-3.amazonaws.com",
-    "eu-south-2": "",
-    "me-central-1": "",
-    "eu-central-2": "",
 }
 
 ENDPOINT_INSTANCE_TYPES = {
@@ -212,11 +202,28 @@ ENDPOINT_INSTANCE_TYPES = {
 TRAINING_JOB_INSTANCE_TYPES = {
     "eu-west-3": "ml.m5.xlarge",
     "eu-north-1": "ml.m5.xlarge",
-    "me-south-1": "ml.m5.xlarge",
+    "ap-northeast-3": "ml.m5.xlarge",
+    "ap-east-1": "ml.m5.xlarge",
+    "me-south-1": "ml.m5.xlarge", 
+    "eu-south-1": "ml.m5.xlarge", 
+    "af-south-1": "ml.m5.xlarge", 
+    "eu-south-2": "ml.m5.xlarge", 
+    "ap-southeast-3": "ml.m5.xlarge", 
+    "me-central-1": "ml.m5.xlarge", 
+    "eu-central-2": "ml.m5.xlarge", 
 }
 
 NOTEBOOK_INSTANCE_INSTANCE_TYPES = {
     "eu-north-1": "ml.t3.medium",
+    "ap-northeast-3": "ml.t3.medium",
+    "ap-east-1": "ml.t3.medium",
+    "me-south-1": "ml.t3.medium", 
+    "eu-south-1": "ml.t3.medium", 
+    "af-south-1": "ml.t3.medium", 
+    "eu-south-2": "ml.t3.medium", 
+    "ap-southeast-3": "ml.t3.medium", 
+    "me-central-1": "ml.t3.medium", 
+    "eu-central-2": "ml.t3.medium", 
 }
 
 REPLACEMENT_VALUES = {

--- a/test/e2e/resources/kmeans_processingjob.yaml
+++ b/test/e2e/resources/kmeans_processingjob.yaml
@@ -21,7 +21,7 @@ spec:
   processingInputs:
     - inputName: mnist_tar
       s3Input:
-        s3URI: s3://sagemaker-sample-data-$AWS_REGION/algorithms/kmeans/mnist/mnist.pkl.gz
+        s3URI: s3://$SAGEMAKER_DATA_BUCKET/sagemaker/processing/algorithms/kmeans/mnist/mnist.pkl.gz
         localPath: /opt/ml/processing/input
         s3DataType: S3Prefix
         s3InputMode: File

--- a/test/e2e/resources/pipeline_processing.yaml
+++ b/test/e2e/resources/pipeline_processing.yaml
@@ -7,7 +7,7 @@ spec:
   pipelineName: $PIPELINE_NAME
   pipelineDefinition: '{"Version": "2020-12-01", "Metadata": {}, "Parameters": [{"Name": "ProcessingInstanceType", 
   "Type": "String", "DefaultValue": "ml.m5.xlarge"}, {"Name": "ProcessingInstanceCount", "Type": "Integer", "DefaultValue": 1}, 
-  {"Name": "InputData", "Type": "String", "DefaultValue": "s3://sagemaker-sample-data-$AWS_REGION/algorithms/kmeans/mnist/mnist.pkl.gz"}], 
+  {"Name": "InputData", "Type": "String", "DefaultValue": "s3://$SAGEMAKER_DATA_BUCKET/sagemaker/processing/algorithms/kmeans/mnist/mnist.pkl.gz"}], 
   "PipelineExperimentConfig": {"ExperimentName": {"Get": "Execution.PipelineName"}, "TrialName": {"Get": "Execution.PipelineExecutionId"}}, 
   "Steps": [{"Name": "PreprocessData", "Type": "Processing", "Arguments": {"ProcessingResources": 
   {"ClusterConfig": {"InstanceType": "ml.m5.large", "InstanceCount": {"Get": "Parameters.ProcessingInstanceCount"}, "VolumeSizeInGB": 20}}, 

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -55,6 +55,8 @@ def sync_data_bucket(bucket) -> str:
                 "sync",
                 f"s3://{SAGEMAKER_SOURCE_DATA_BUCKET}",
                 f"./{temp_dir}/",
+                "--region",
+                "us-west-2",
                 "--quiet",
             ]
         )

--- a/test/e2e/tests/test_endpoint.py
+++ b/test/e2e/tests/test_endpoint.py
@@ -218,6 +218,7 @@ def faulty_config(name_suffix, single_container_model):
 
 
 @service_marker
+@pytest.mark.shallow_canary
 @pytest.mark.canary
 class TestEndpoint:
     def create_endpoint_test(self, xgboost_endpoint):

--- a/test/e2e/tests/test_endpoint_config.py
+++ b/test/e2e/tests/test_endpoint_config.py
@@ -74,6 +74,7 @@ def single_variant_config():
 
 
 @service_marker
+@pytest.mark.shallow_canary
 @pytest.mark.canary
 class TestEndpointConfig:
     def test_create_endpoint_config(self, single_variant_config):

--- a/test/e2e/tests/test_endpoint_config.py
+++ b/test/e2e/tests/test_endpoint_config.py
@@ -74,7 +74,6 @@ def single_variant_config():
 
 
 @service_marker
-@pytest.mark.shallow_canary
 @pytest.mark.canary
 class TestEndpointConfig:
     def test_create_endpoint_config(self, single_variant_config):

--- a/test/e2e/tests/test_trainingjob.py
+++ b/test/e2e/tests/test_trainingjob.py
@@ -85,6 +85,7 @@ class TestTrainingJob:
         training_job_desc = get_sagemaker_training_job(training_job_name)
         assert training_job_desc["TrainingJobStatus"] in cfg.LIST_JOB_STATUS_STOPPED
 
+    @pytest.mark.shallow_canary
     @pytest.mark.canary
     def test_completed(self, xgboost_training_job):
         (reference, resource) = xgboost_training_job


### PR DESCRIPTION
    - Create shallow canary marker for eu-south-2, ap-southeast-3,
    me-central-1, eu-central-2, since some registries are not available in
    those regions.
    - Add training and hosting to shallow canary
    - Add `--region ` for `aws s3 sync` to prevent error when downloading s3
    bucket data to temp directory.
    - Remove dependency on `s3://sagemaker-sample-data-$AWS_REGION `