### PR TITLE
modify canary to use shallow from env

### DIFF
--- a/test/canary/scripts/run_test.sh
+++ b/test/canary/scripts/run_test.sh
@@ -97,7 +97,7 @@ pushd $E2E_DIR
   if [[ $SERVICE_REGION =~ ^(eu-north-1|eu-west-3)$  ]]; then
     # If select_regions_1 true we run the notebook_instance test
     pytest_args+=(-m "canary or select_regions_1")
-  elif [[ $SERVICE_REGION =~ ^(eu-south-2|ap-southeast-3|me-central-1|eu-central-2)$  ]]; then
+  elif [[ $SHALLOW_REGION = "shallow"  ]]; then
     pytest_args+=(-m "shallow_canary")
   else
     pytest_args+=(-m "canary")

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,3 +1,3 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@0bf619e4653b31346a8f39de7b6ad8a1d1317ef2
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@c7d61848a9011c05410da20392de637cc8d8a7da
 black==20.8b1
 flaky==3.7.0


### PR DESCRIPTION
Issue #, if available: n/a

Description of changes:

- Modifying the run_test script to add the shallow marker based off an environment variable rather than having it in the script

Testing

- Tested inside one of the canaries 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
