### PR TITLE
Cherry-Pick: Lock Pytest to 8.0.2

### DIFF
--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,3 +1,4 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@c7d61848a9011c05410da20392de637cc8d8a7da
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@66d07f4daa2ce12d92f07cb332d5342a0aea4feb
+pytest==8.0.2
 black==20.8b1
 flaky==3.7.0


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: Cherrypick (#264)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
