### PR TITLE
Bugfix - handled panic due to difference in InputdataConfig size 

### DIFF
--- a/pkg/resource/training_job/custom_delta.go
+++ b/pkg/resource/training_job/custom_delta.go
@@ -55,7 +55,7 @@ func customSetDefaults(
 
 	if ackcompare.IsNotNil(a.ko.Spec.InputDataConfig) && ackcompare.IsNotNil(b.ko.Spec.InputDataConfig) {
 		for index := range a.ko.Spec.InputDataConfig {
-			if ackcompare.IsNil(a.ko.Spec.InputDataConfig[index].RecordWrapperType) && ackcompare.IsNotNil(b.ko.Spec.InputDataConfig[index].RecordWrapperType) {
+			if (ackcompare.IsNil(a.ko.Spec.InputDataConfig[index].RecordWrapperType) && index >= len(b.ko.Spec.InputDataConfig)) || ackcompare.IsNil(a.ko.Spec.InputDataConfig[index].RecordWrapperType) && ackcompare.IsNotNil(b.ko.Spec.InputDataConfig[index].RecordWrapperType) {
 				a.ko.Spec.InputDataConfig[index].RecordWrapperType = defaultRecordWrapperType
 			}
 		}


### PR DESCRIPTION
Description of changes:

The change handles panic due to **runtime error : index out of range**  . The present code accesses b.ko.Spec.InputDataConfig[index] which can throw panic if size of b.ko.Spec.InputDataConfig is smaller than a.ko.Spec.InputDataConfig 

The solution checks for this condition and sets the a.ko.Spec.InputDataConfig[index].RecordWrapperType to default type 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
