### PR TITLE
test: Adding timeout for integration test

### DIFF
--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -2,3 +2,4 @@ acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@66d07f4daa2c
 pytest==8.0.2
 black==20.8b1
 flaky==3.7.0
+pytest-timeout==2.3.1

--- a/test/e2e/tests/test_inference_component.py
+++ b/test/e2e/tests/test_inference_component.py
@@ -207,6 +207,7 @@ def faulty_model(name_suffix, xgboost_model):
 
 @service_marker
 @pytest.mark.inference_component
+@pytest.mark.timeout(3600) # 1 hour timeout
 class TestInferenceComponent:
     def create_inference_component_test(self, inference_component):
         (reference, resource, _) = inference_component


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Inference component integration test can sometimes time out, this pull request adds a marker to time out at 1 hour.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
