### PR TITLE
Increase the timeout for creation of feature group

### DIFF
--- a/test/e2e/tests/test_feature_group.py
+++ b/test/e2e/tests/test_feature_group.py
@@ -38,7 +38,7 @@ SPEC_FILE = "feature_group"
 FEATURE_GROUP_STATUS_CREATING = "Creating"
 FEATURE_GROUP_STATUS_CREATED = "Created"
 # longer wait is used because we sometimes see server taking time to create/delete
-WAIT_PERIOD_COUNT = 20
+WAIT_PERIOD_COUNT = 40
 WAIT_PERIOD_LENGTH = 30
 STATUS = "status"
 RESOURCE_STATUS = "featureGroupStatus"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Sometimes creation of feature group takes more than 10 minutes causing canary to Fail. SoIncrease the timeout from 20 to 40 for creation of feature group.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.