### PR TITLE
tests: Ready condition rename for sagemaker-controller

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-09-20T00:39:31Z"
-  build_hash: 5bf1e456e1dfc638d47ab492376335f528c0f455
-  go_version: go1.25.0
-  version: v0.52.0-1-g5bf1e45
+  build_date: "2025-09-25T06:05:12Z"
+  build_hash: 9c388d9668ea19d0b1b65566d492c4f67c6e64c8
+  go_version: go1.24.7
+  version: 9c388d9
 api_directory_checksum: 0b6625eb2e0b359687d13920cd0bb353a21e0e19
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/config/crd/bases/sagemaker.services.k8s.aws_apps.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_apps.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: apps.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_dataqualityjobdefinitions.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_dataqualityjobdefinitions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: dataqualityjobdefinitions.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_domains.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_domains.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: domains.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_endpointconfigs.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_endpointconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: endpointconfigs.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_endpoints.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_endpoints.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: endpoints.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_featuregroups.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_featuregroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: featuregroups.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_hyperparametertuningjobs.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_hyperparametertuningjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: hyperparametertuningjobs.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_inferencecomponents.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_inferencecomponents.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: inferencecomponents.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_labelingjobs.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_labelingjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: labelingjobs.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_modelbiasjobdefinitions.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_modelbiasjobdefinitions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: modelbiasjobdefinitions.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_modelexplainabilityjobdefinitions.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_modelexplainabilityjobdefinitions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: modelexplainabilityjobdefinitions.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_modelpackagegroups.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_modelpackagegroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: modelpackagegroups.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_modelpackages.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_modelpackages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: modelpackages.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_modelqualityjobdefinitions.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_modelqualityjobdefinitions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: modelqualityjobdefinitions.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_models.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_models.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: models.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_monitoringschedules.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_monitoringschedules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: monitoringschedules.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_notebookinstancelifecycleconfigs.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_notebookinstancelifecycleconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: notebookinstancelifecycleconfigs.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_notebookinstances.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_notebookinstances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: notebookinstances.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_pipelineexecutions.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_pipelineexecutions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: pipelineexecutions.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_pipelines.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_pipelines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: pipelines.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_processingjobs.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_processingjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: processingjobs.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_trainingjobs.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_trainingjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: trainingjobs.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_transformjobs.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_transformjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: transformjobs.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/config/crd/bases/sagemaker.services.k8s.aws_userprofiles.yaml
+++ b/config/crd/bases/sagemaker.services.k8s.aws_userprofiles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: userprofiles.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/go.mod
+++ b/go.mod
@@ -91,3 +91,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
@@ -86,6 +84,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.57.0 h1:85zJyvdPpzOTaWE0icljJcMRf0qlP0oWdOT05hMZ6Z0=
+github.com/gustavodiaz7722/ack-runtime v0.57.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/helm/crds/sagemaker.services.k8s.aws_apps.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_apps.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: apps.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_dataqualityjobdefinitions.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_dataqualityjobdefinitions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: dataqualityjobdefinitions.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_domains.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_domains.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: domains.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_endpointconfigs.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_endpointconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: endpointconfigs.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_endpoints.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_endpoints.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: endpoints.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_featuregroups.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_featuregroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: featuregroups.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_hyperparametertuningjobs.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_hyperparametertuningjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: hyperparametertuningjobs.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_inferencecomponents.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_inferencecomponents.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: inferencecomponents.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_labelingjobs.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_labelingjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: labelingjobs.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_modelbiasjobdefinitions.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_modelbiasjobdefinitions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: modelbiasjobdefinitions.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_modelexplainabilityjobdefinitions.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_modelexplainabilityjobdefinitions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: modelexplainabilityjobdefinitions.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_modelpackagegroups.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_modelpackagegroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: modelpackagegroups.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_modelpackages.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_modelpackages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: modelpackages.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_modelqualityjobdefinitions.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_modelqualityjobdefinitions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: modelqualityjobdefinitions.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_models.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_models.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: models.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_monitoringschedules.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_monitoringschedules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: monitoringschedules.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_notebookinstancelifecycleconfigs.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_notebookinstancelifecycleconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: notebookinstancelifecycleconfigs.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_notebookinstances.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_notebookinstances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: notebookinstances.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_pipelineexecutions.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_pipelineexecutions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: pipelineexecutions.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_pipelines.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_pipelines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: pipelines.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_processingjobs.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_processingjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: processingjobs.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_trainingjobs.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_trainingjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: trainingjobs.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_transformjobs.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_transformjobs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: transformjobs.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/sagemaker.services.k8s.aws_userprofiles.yaml
+++ b/helm/crds/sagemaker.services.k8s.aws_userprofiles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: userprofiles.sagemaker.services.k8s.aws
 spec:
   group: sagemaker.services.k8s.aws

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: adoptedresources.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/helm/crds/services.k8s.aws_fieldexports.yaml
+++ b/helm/crds/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,4 +1,4 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@66d07f4daa2ce12d92f07cb332d5342a0aea4feb
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@4a5c296da0fe386eadf95c242591ae4724cd0428
 pytest==8.0.2
 black==20.8b1
 flaky==3.7.0

--- a/test/e2e/tests/test_adopt_endpoint.py
+++ b/test/e2e/tests/test_adopt_endpoint.py
@@ -244,7 +244,7 @@ class TestAdoptedEndpoint:
             cfg.ENDPOINT_STATUS_INSERVICE,
         )
         assert k8s.wait_on_condition(
-            endpoint_reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            endpoint_reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         for cr in (model_reference, config_reference, endpoint_reference):

--- a/test/e2e/tests/test_adopt_model_package.py
+++ b/test/e2e/tests/test_adopt_model_package.py
@@ -233,7 +233,7 @@ class TestAdoptedModelPackage:
             cfg.JOB_STATUS_COMPLETED,
         )
         assert k8s.wait_on_condition(
-            model_package_reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            model_package_reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         for cr in (model_package_reference, model_package_group_reference):

--- a/test/e2e/tests/test_endpoint.py
+++ b/test/e2e/tests/test_endpoint.py
@@ -231,12 +231,12 @@ class TestEndpoint:
         # endpoint transitions Creating -> InService state
         assert_endpoint_status_in_sync(endpoint_name, reference, cfg.ENDPOINT_STATUS_CREATING)
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         assert_endpoint_status_in_sync(endpoint_name, reference, cfg.ENDPOINT_STATUS_INSERVICE)
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         resource_tags = resource["spec"].get("tags", None)
@@ -258,7 +258,7 @@ class TestEndpoint:
             cfg.ENDPOINT_STATUS_UPDATING,
         )
         assert k8s.wait_on_condition(
-            endpoint_reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            endpoint_reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
         endpoint_resource = k8s.get_resource(endpoint_reference)
         annotations = endpoint_resource["metadata"].get("annotations", None)
@@ -272,7 +272,7 @@ class TestEndpoint:
         )
 
         assert k8s.wait_on_condition(
-            endpoint_reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            endpoint_reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         (_, old_config_resource) = single_variant_config
@@ -310,7 +310,7 @@ class TestEndpoint:
         )
 
         assert k8s.wait_on_condition(
-            endpoint_reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            endpoint_reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
         assert (
             k8s.get_resource_condition(endpoint_reference, ack_condition.CONDITION_TYPE_TERMINAL)
@@ -327,7 +327,7 @@ class TestEndpoint:
             cfg.ENDPOINT_STATUS_INSERVICE,
         )
         assert k8s.wait_on_condition(
-            endpoint_reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            endpoint_reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
         assert (
             k8s.get_resource_condition(endpoint_reference, ack_condition.CONDITION_TYPE_TERMINAL)

--- a/test/e2e/tests/test_feature_group.py
+++ b/test/e2e/tests/test_feature_group.py
@@ -144,7 +144,7 @@ class TestFeatureGroup:
         )
 
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         resource_tags = resource["spec"].get("tags", None)

--- a/test/e2e/tests/test_hpo.py
+++ b/test/e2e/tests/test_hpo.py
@@ -134,7 +134,7 @@ class TestHPO:
         assert k8s.get_resource_arn(resource) == hpo_sm_desc["HyperParameterTuningJobArn"]
         assert hpo_sm_desc["HyperParameterTuningJobStatus"] == cfg.JOB_STATUS_INPROGRESS
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         self._assert_hpo_status_in_sync(hpo_job_name, reference, cfg.JOB_STATUS_INPROGRESS)
@@ -161,12 +161,12 @@ class TestHPO:
 
         assert hpo_sm_desc["HyperParameterTuningJobStatus"] == cfg.JOB_STATUS_INPROGRESS
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         self._assert_hpo_status_in_sync(hpo_job_name, reference, cfg.JOB_STATUS_COMPLETED)
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         resource_tags = resource["spec"].get("tags", None)

--- a/test/e2e/tests/test_inference_component.py
+++ b/test/e2e/tests/test_inference_component.py
@@ -127,12 +127,12 @@ def endpoint(name_suffix, endpoint_config):
     # endpoint transitions Creating -> InService state
     assert_endpoint_status_in_sync(endpoint_name, endpoint_reference, cfg.ENDPOINT_STATUS_CREATING)
     assert k8s.wait_on_condition(
-        endpoint_reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+        endpoint_reference, ack_condition.CONDITION_TYPE_READY, "False"
     )
 
     assert_endpoint_status_in_sync(endpoint_name, endpoint_reference, cfg.ENDPOINT_STATUS_INSERVICE)
     assert k8s.wait_on_condition(
-        endpoint_reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+        endpoint_reference, ack_condition.CONDITION_TYPE_READY, "True"
     )
 
     yield (endpoint_reference, endpoint_resource)
@@ -226,14 +226,14 @@ class TestInferenceComponent:
             inference_component_name, reference, cfg.INFERENCE_COMPONENT_STATUS_CREATING
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         assert_inference_component_status_in_sync(
             inference_component_name, reference, cfg.INFERENCE_COMPONENT_STATUS_INSERVICE
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         resource_tags = resource["spec"].get("tags", None)
@@ -256,7 +256,7 @@ class TestInferenceComponent:
         )
 
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
         assert k8s.get_resource_condition(reference, ack_condition.CONDITION_TYPE_TERMINAL) is None
         resource = k8s.get_resource(reference)
@@ -268,7 +268,7 @@ class TestInferenceComponent:
         )
 
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         assert k8s.assert_condition_state_message(
@@ -305,7 +305,7 @@ class TestInferenceComponent:
         )
 
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
         assert k8s.get_resource_condition(reference, ack_condition.CONDITION_TYPE_TERMINAL) is None
         resource = k8s.get_resource(reference)
@@ -316,7 +316,7 @@ class TestInferenceComponent:
             cfg.INFERENCE_COMPONENT_STATUS_INSERVICE,
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
         assert k8s.get_resource_condition(reference, ack_condition.CONDITION_TYPE_TERMINAL) is None
         resource = k8s.get_resource(reference)

--- a/test/e2e/tests/test_labelingjob.py
+++ b/test/e2e/tests/test_labelingjob.py
@@ -134,7 +134,7 @@ class TestLabelingJob:
         assert k8s.get_resource_arn(resource) == labeling_job_desc["LabelingJobArn"]
         assert labeling_job_desc["LabelingJobStatus"] == cfg.JOB_STATUS_INPROGRESS
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         self._assert_labeling_status_in_sync(

--- a/test/e2e/tests/test_model_package.py
+++ b/test/e2e/tests/test_model_package.py
@@ -186,14 +186,14 @@ class TestmodelPackage:
             model_package_name, reference, cfg.JOB_STATUS_INPROGRESS
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         self._assert_model_package_status_in_sync(
             model_package_name, reference, cfg.JOB_STATUS_COMPLETED
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         resource_tags = resource["spec"].get("tags", None)
@@ -226,14 +226,14 @@ class TestmodelPackage:
             model_package_name, reference, cfg.JOB_STATUS_INPROGRESS
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         self._assert_model_package_status_in_sync(
             model_package_name, reference, cfg.JOB_STATUS_COMPLETED
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         # Update the resource
@@ -249,7 +249,7 @@ class TestmodelPackage:
             model_package_name, reference, cfg.JOB_STATUS_COMPLETED
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         model_package_desc = get_sagemaker_model_package(model_package_name)

--- a/test/e2e/tests/test_model_package_group.py
+++ b/test/e2e/tests/test_model_package_group.py
@@ -125,7 +125,7 @@ class TestModelPackageGroup:
             model_package_group_name, reference, cfg.JOB_STATUS_COMPLETED
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         resource_tags = resource["spec"].get("tags", None)

--- a/test/e2e/tests/test_monitoring_schedule.py
+++ b/test/e2e/tests/test_monitoring_schedule.py
@@ -164,7 +164,7 @@ class TestMonitoringSchedule:
             sagemaker_client, monitoring_schedule_name, reference, self.STATUS_SCHEDULED
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         resource_tags = resource["spec"].get("tags", None)
@@ -183,7 +183,7 @@ class TestMonitoringSchedule:
             sagemaker_client, monitoring_schedule_name, reference, self.STATUS_SCHEDULED
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         latest_schedule = get_sagemaker_monitoring_schedule(

--- a/test/e2e/tests/test_notebook_instance.py
+++ b/test/e2e/tests/test_notebook_instance.py
@@ -148,14 +148,14 @@ class TestNotebookInstance:
         assert notebook_description["NotebookInstanceStatus"] == "Pending"
 
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
         self._assert_notebook_status_in_sync(notebook_instance_name, reference, "Pending")
 
         # wait for the resource to go to the InService state and make sure the operator is synced with sagemaker.
         self._assert_notebook_status_in_sync(notebook_instance_name, reference, "InService")
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
     def update_notebook_test(self, notebook_instance):
@@ -185,7 +185,7 @@ class TestNotebookInstance:
         # wait for the resource to go to the InService state and make sure the operator is synced with sagemaker.
         self._assert_notebook_status_in_sync(notebook_instance_name, reference, "InService")
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         notebook_instance_desc = get_notebook_instance(notebook_instance_name)

--- a/test/e2e/tests/test_pipeline.py
+++ b/test/e2e/tests/test_pipeline.py
@@ -141,7 +141,7 @@ class TestPipeline:
 
         self._assert_pipeline_status_in_sync(pipeline_arn, reference, "Active")
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         # Update the resource
@@ -153,7 +153,7 @@ class TestPipeline:
 
         self._assert_pipeline_status_in_sync(pipeline_arn, reference, "Active")
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         pipeline_desc = get_sagemaker_pipeline(pipeline_name)

--- a/test/e2e/tests/test_pipeline_execution.py
+++ b/test/e2e/tests/test_pipeline_execution.py
@@ -180,7 +180,7 @@ class TestPipelineExecution:
         )
 
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         # Update the resource
@@ -194,7 +194,7 @@ class TestPipelineExecution:
             pipeline_execution_arn, reference, cfg.JOB_STATUS_EXECUTING
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         pipeline_execution_desc = get_sagemaker_pipeline_execution(pipeline_execution_arn)
@@ -215,7 +215,7 @@ class TestPipelineExecution:
             pipeline_execution_arn, reference, cfg.JOB_STATUS_SUCCEEDED
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         # Check that you can delete a completed resource from k8s

--- a/test/e2e/tests/test_processingjob.py
+++ b/test/e2e/tests/test_processingjob.py
@@ -134,7 +134,7 @@ class TestProcessingJob:
         assert k8s.get_resource_arn(resource) == processing_job_desc["ProcessingJobArn"]
         assert processing_job_desc["ProcessingJobStatus"] == cfg.JOB_STATUS_INPROGRESS
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         self._assert_processing_status_in_sync(
@@ -163,14 +163,14 @@ class TestProcessingJob:
 
         assert processing_job_desc["ProcessingJobStatus"] == cfg.JOB_STATUS_INPROGRESS
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         self._assert_processing_status_in_sync(
             processing_job_name, reference, cfg.JOB_STATUS_COMPLETED
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         resource_tags = resource["spec"].get("tags", None)

--- a/test/e2e/tests/test_trainingjob.py
+++ b/test/e2e/tests/test_trainingjob.py
@@ -72,7 +72,7 @@ class TestTrainingJob:
         assert k8s.get_resource_arn(resource) == training_job_desc["TrainingJobArn"]
         assert training_job_desc["TrainingJobStatus"] == cfg.JOB_STATUS_INPROGRESS
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         assert_training_status_in_sync(training_job_name, reference, cfg.JOB_STATUS_INPROGRESS)
@@ -100,12 +100,12 @@ class TestTrainingJob:
 
         assert training_job_desc["TrainingJobStatus"] == cfg.JOB_STATUS_INPROGRESS
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         assert_training_status_in_sync(training_job_name, reference, cfg.JOB_STATUS_COMPLETED)
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         # model artifact URL is populated

--- a/test/e2e/tests/test_trainingjob_debugger.py
+++ b/test/e2e/tests/test_trainingjob_debugger.py
@@ -148,7 +148,7 @@ class TestTrainingDebuggerJob:
 
         assert training_job_desc["TrainingJobStatus"] == cfg.JOB_STATUS_INPROGRESS
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         spec["spec"]["profilerConfig"]["profilingIntervalInMilliseconds"] = NEW_PROFILER_INTERVAL
@@ -156,7 +156,7 @@ class TestTrainingDebuggerJob:
 
         assert_training_status_in_sync(training_job_name, reference, cfg.JOB_STATUS_COMPLETED)
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         # Assert debugger rule evaluation completed
@@ -169,7 +169,7 @@ class TestTrainingDebuggerJob:
             training_job_name, "ProfilerRule", reference, cfg.RULE_STATUS_COMPLETED
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         # Check if the update worked.

--- a/test/e2e/tests/test_transformjob.py
+++ b/test/e2e/tests/test_transformjob.py
@@ -168,7 +168,7 @@ class TestTransformJob:
         assert k8s.get_resource_arn(resource) == transform_sm_desc["TransformJobArn"]
         assert transform_sm_desc["TransformJobStatus"] == cfg.JOB_STATUS_INPROGRESS
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         self._assert_transform_status_in_sync(
@@ -197,14 +197,14 @@ class TestTransformJob:
 
         assert transform_sm_desc["TransformJobStatus"] == cfg.JOB_STATUS_INPROGRESS
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "False"
+            reference, ack_condition.CONDITION_TYPE_READY, "False"
         )
 
         self._assert_transform_status_in_sync(
             transform_job_name, reference, cfg.JOB_STATUS_COMPLETED
         )
         assert k8s.wait_on_condition(
-            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+            reference, ack_condition.CONDITION_TYPE_READY, "True"
         )
 
         resource_tags = resource["spec"].get("tags", None)


### PR DESCRIPTION
This PR updates controller src and test files to the Ready condition:

- Run code generation 
- Update test infra commit id 
- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.

_No manual changes were made to the controller source; all changes were made via automated script._