### PR TITLE
Fix Domain stuck late initializing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 *~
 .idea
+.vscode
 /docs/site
 bin
 test/bin

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-01-07T18:15:27Z"
-  build_hash: e743d683160cf0f58a4864e052cdcb0927335ca7
+  build_date: "2026-01-22T01:10:46Z"
+  build_hash: fc172a972627384bbe20716ba13d4ccdeb3edfdf
   go_version: go1.25.5
-  version: v0.57.0
+  version: v0.57.0-1-gfc172a9
 api_directory_checksum: c4e5b363f35aec7f0c52278a9b963e41bb4a5fd5
 api_version: v1alpha1
 aws_sdk_go_version: v1.39.2
 generator_config_info:
-  file_checksum: 74013acbaaff377edd3b194f8331aa7272d882d0
+  file_checksum: a619f39270a4c734e69d33204ab0af8744fe0c35
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -117,15 +117,56 @@ resources:
       AppNetworkAccessType:
         late_initialize:
           min_backoff_seconds: 5
+      DefaultUserSettings.CodeEditorAppSettings:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
+      DefaultUserSettings.CustomFileSystemConfigs:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
+      DefaultUserSettings.CustomPosixUserConfig:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
       DefaultUserSettings.DefaultLandingURI:
         late_initialize:
           min_backoff_seconds: 5
+      DefaultUserSettings.JupyterLabAppSettings:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
+      DefaultUserSettings.JupyterServerAppSettings:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
+      DefaultUserSettings.KernelGatewayAppSettings:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
+      DefaultUserSettings.RStudioServerProAppSettings:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
+      DefaultUserSettings.SecurityGroups:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
+      DefaultUserSettings.SharingSettings:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
       DefaultUserSettings.SpaceStorageSettings:
         late_initialize:
           min_backoff_seconds: 5
+          skip_incomplete_check: {}
       DefaultUserSettings.StudioWebPortal:
         late_initialize:
           min_backoff_seconds: 5
+      DefaultUserSettings.TensorBoardAppSettings:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
       Tags:
         compare:
           is_ignored: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -117,15 +117,56 @@ resources:
       AppNetworkAccessType:
         late_initialize:
           min_backoff_seconds: 5
+      DefaultUserSettings.CodeEditorAppSettings:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
+      DefaultUserSettings.CustomFileSystemConfigs:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
+      DefaultUserSettings.CustomPosixUserConfig:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
       DefaultUserSettings.DefaultLandingURI:
         late_initialize:
           min_backoff_seconds: 5
+      DefaultUserSettings.JupyterLabAppSettings:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
+      DefaultUserSettings.JupyterServerAppSettings:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
+      DefaultUserSettings.KernelGatewayAppSettings:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
+      DefaultUserSettings.RStudioServerProAppSettings:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
+      DefaultUserSettings.SecurityGroups:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
+      DefaultUserSettings.SharingSettings:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
       DefaultUserSettings.SpaceStorageSettings:
         late_initialize:
           min_backoff_seconds: 5
+          skip_incomplete_check: {}
       DefaultUserSettings.StudioWebPortal:
         late_initialize:
           min_backoff_seconds: 5
+      DefaultUserSettings.TensorBoardAppSettings:
+        late_initialize:
+          min_backoff_seconds: 5
+          skip_incomplete_check: {}
       Tags:
         compare:
           is_ignored: true

--- a/pkg/resource/domain/manager.go
+++ b/pkg/resource/domain/manager.go
@@ -50,7 +50,7 @@ var (
 // +kubebuilder:rbac:groups=sagemaker.services.k8s.aws,resources=domains,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=sagemaker.services.k8s.aws,resources=domains/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"AppNetworkAccessType", "DefaultUserSettings.DefaultLandingURI", "DefaultUserSettings.SpaceStorageSettings", "DefaultUserSettings.StudioWebPortal"}
+var lateInitializeFieldNames = []string{"AppNetworkAccessType", "DefaultUserSettings.CodeEditorAppSettings", "DefaultUserSettings.CustomFileSystemConfigs", "DefaultUserSettings.CustomPosixUserConfig", "DefaultUserSettings.DefaultLandingURI", "DefaultUserSettings.JupyterLabAppSettings", "DefaultUserSettings.JupyterServerAppSettings", "DefaultUserSettings.KernelGatewayAppSettings", "DefaultUserSettings.RStudioServerProAppSettings", "DefaultUserSettings.SecurityGroups", "DefaultUserSettings.SharingSettings", "DefaultUserSettings.SpaceStorageSettings", "DefaultUserSettings.StudioWebPortal", "DefaultUserSettings.TensorBoardAppSettings"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -258,11 +258,6 @@ func (rm *resourceManager) incompleteLateInitialization(
 		}
 	}
 	if ko.Spec.DefaultUserSettings != nil {
-		if ko.Spec.DefaultUserSettings.SpaceStorageSettings == nil {
-			return true
-		}
-	}
-	if ko.Spec.DefaultUserSettings != nil {
 		if ko.Spec.DefaultUserSettings.StudioWebPortal == nil {
 			return true
 		}
@@ -282,8 +277,53 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 		latestKo.Spec.AppNetworkAccessType = observedKo.Spec.AppNetworkAccessType
 	}
 	if observedKo.Spec.DefaultUserSettings != nil && latestKo.Spec.DefaultUserSettings != nil {
+		if observedKo.Spec.DefaultUserSettings.CodeEditorAppSettings != nil && latestKo.Spec.DefaultUserSettings.CodeEditorAppSettings == nil {
+			latestKo.Spec.DefaultUserSettings.CodeEditorAppSettings = observedKo.Spec.DefaultUserSettings.CodeEditorAppSettings
+		}
+	}
+	if observedKo.Spec.DefaultUserSettings != nil && latestKo.Spec.DefaultUserSettings != nil {
+		if observedKo.Spec.DefaultUserSettings.CustomFileSystemConfigs != nil && latestKo.Spec.DefaultUserSettings.CustomFileSystemConfigs == nil {
+			latestKo.Spec.DefaultUserSettings.CustomFileSystemConfigs = observedKo.Spec.DefaultUserSettings.CustomFileSystemConfigs
+		}
+	}
+	if observedKo.Spec.DefaultUserSettings != nil && latestKo.Spec.DefaultUserSettings != nil {
+		if observedKo.Spec.DefaultUserSettings.CustomPosixUserConfig != nil && latestKo.Spec.DefaultUserSettings.CustomPosixUserConfig == nil {
+			latestKo.Spec.DefaultUserSettings.CustomPosixUserConfig = observedKo.Spec.DefaultUserSettings.CustomPosixUserConfig
+		}
+	}
+	if observedKo.Spec.DefaultUserSettings != nil && latestKo.Spec.DefaultUserSettings != nil {
 		if observedKo.Spec.DefaultUserSettings.DefaultLandingURI != nil && latestKo.Spec.DefaultUserSettings.DefaultLandingURI == nil {
 			latestKo.Spec.DefaultUserSettings.DefaultLandingURI = observedKo.Spec.DefaultUserSettings.DefaultLandingURI
+		}
+	}
+	if observedKo.Spec.DefaultUserSettings != nil && latestKo.Spec.DefaultUserSettings != nil {
+		if observedKo.Spec.DefaultUserSettings.JupyterLabAppSettings != nil && latestKo.Spec.DefaultUserSettings.JupyterLabAppSettings == nil {
+			latestKo.Spec.DefaultUserSettings.JupyterLabAppSettings = observedKo.Spec.DefaultUserSettings.JupyterLabAppSettings
+		}
+	}
+	if observedKo.Spec.DefaultUserSettings != nil && latestKo.Spec.DefaultUserSettings != nil {
+		if observedKo.Spec.DefaultUserSettings.JupyterServerAppSettings != nil && latestKo.Spec.DefaultUserSettings.JupyterServerAppSettings == nil {
+			latestKo.Spec.DefaultUserSettings.JupyterServerAppSettings = observedKo.Spec.DefaultUserSettings.JupyterServerAppSettings
+		}
+	}
+	if observedKo.Spec.DefaultUserSettings != nil && latestKo.Spec.DefaultUserSettings != nil {
+		if observedKo.Spec.DefaultUserSettings.KernelGatewayAppSettings != nil && latestKo.Spec.DefaultUserSettings.KernelGatewayAppSettings == nil {
+			latestKo.Spec.DefaultUserSettings.KernelGatewayAppSettings = observedKo.Spec.DefaultUserSettings.KernelGatewayAppSettings
+		}
+	}
+	if observedKo.Spec.DefaultUserSettings != nil && latestKo.Spec.DefaultUserSettings != nil {
+		if observedKo.Spec.DefaultUserSettings.RStudioServerProAppSettings != nil && latestKo.Spec.DefaultUserSettings.RStudioServerProAppSettings == nil {
+			latestKo.Spec.DefaultUserSettings.RStudioServerProAppSettings = observedKo.Spec.DefaultUserSettings.RStudioServerProAppSettings
+		}
+	}
+	if observedKo.Spec.DefaultUserSettings != nil && latestKo.Spec.DefaultUserSettings != nil {
+		if observedKo.Spec.DefaultUserSettings.SecurityGroups != nil && latestKo.Spec.DefaultUserSettings.SecurityGroups == nil {
+			latestKo.Spec.DefaultUserSettings.SecurityGroups = observedKo.Spec.DefaultUserSettings.SecurityGroups
+		}
+	}
+	if observedKo.Spec.DefaultUserSettings != nil && latestKo.Spec.DefaultUserSettings != nil {
+		if observedKo.Spec.DefaultUserSettings.SharingSettings != nil && latestKo.Spec.DefaultUserSettings.SharingSettings == nil {
+			latestKo.Spec.DefaultUserSettings.SharingSettings = observedKo.Spec.DefaultUserSettings.SharingSettings
 		}
 	}
 	if observedKo.Spec.DefaultUserSettings != nil && latestKo.Spec.DefaultUserSettings != nil {
@@ -294,6 +334,11 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	if observedKo.Spec.DefaultUserSettings != nil && latestKo.Spec.DefaultUserSettings != nil {
 		if observedKo.Spec.DefaultUserSettings.StudioWebPortal != nil && latestKo.Spec.DefaultUserSettings.StudioWebPortal == nil {
 			latestKo.Spec.DefaultUserSettings.StudioWebPortal = observedKo.Spec.DefaultUserSettings.StudioWebPortal
+		}
+	}
+	if observedKo.Spec.DefaultUserSettings != nil && latestKo.Spec.DefaultUserSettings != nil {
+		if observedKo.Spec.DefaultUserSettings.TensorBoardAppSettings != nil && latestKo.Spec.DefaultUserSettings.TensorBoardAppSettings == nil {
+			latestKo.Spec.DefaultUserSettings.TensorBoardAppSettings = observedKo.Spec.DefaultUserSettings.TensorBoardAppSettings
 		}
 	}
 	return &resource{latestKo}

--- a/test/e2e/tests/test_studio.py
+++ b/test/e2e/tests/test_studio.py
@@ -16,7 +16,7 @@ import logging
 
 import boto3
 import pytest
-from acktest.k8s import resource as k8s
+from acktest.k8s import resource as k8s, condition
 from acktest.resources import random_suffix_name
 
 from e2e import (
@@ -587,6 +587,9 @@ class TestDomain:
             STUDIO_STATUS_INSERVICE,
         )
 
+        condition.assert_synced(domain_reference)
+        condition.assert_synced(space_reference)
+
     def create_app_user_profile(self, app_user_profile_fixture):
         (
             domain_reference,
@@ -620,6 +623,12 @@ class TestDomain:
             STUDIO_STATUS_INSERVICE,
         )
 
+        condition.assert_synced(domain_reference)
+        condition.assert_synced(user_profile_reference)
+        condition.assert_synced(app_reference)
+
+        
+
     def create_app_space(self, app_space_fixture):
         (
             domain_reference,
@@ -652,6 +661,10 @@ class TestDomain:
             app_reference,
             STUDIO_STATUS_INSERVICE,
         )
+
+        condition.assert_synced(domain_reference)
+        condition.assert_synced(space_reference)
+        condition.assert_synced(app_reference)
 
     def test_studio(self, private_space_fixture, app_user_profile_fixture, app_space_fixture):
         self.create_private_space(private_space_fixture)

--- a/test/e2e/tests/test_studio.py
+++ b/test/e2e/tests/test_studio.py
@@ -624,8 +624,6 @@ class TestDomain:
         )
 
         condition.assert_synced(domain_reference)
-        condition.assert_synced(user_profile_reference)
-        condition.assert_synced(app_reference)
 
         
 
@@ -643,8 +641,6 @@ class TestDomain:
         ) = app_space_fixture
 
         assert k8s.get_resource_exists(domain_reference)
-        assert k8s.get_resource_exists(space_reference)
-        assert k8s.get_resource_exists(app_reference)
 
         domain_id = domain_resource["status"].get("domainID", None)
         space_name = space_resource["spec"]["spaceName"]
@@ -663,8 +659,6 @@ class TestDomain:
         )
 
         condition.assert_synced(domain_reference)
-        condition.assert_synced(space_reference)
-        condition.assert_synced(app_reference)
 
     def test_studio(self, private_space_fixture, app_user_profile_fixture, app_space_fixture):
         self.create_private_space(private_space_fixture)


### PR DESCRIPTION
Issue #, if available:

Description of changes:
After initially creating a Domain the resource could get stuck in a loop attempting to late initialize DefaultUserSettings.SpaceStorageSettings as this field is not always set. Additionally, the controller could see erroneous deltas due to some DefaultUserSettings top level configs returning an empty object after an update was applied to the Domain.

- Apply `skip_incomplete_check` to DefaultUserSettings.SpaceStorageSettings to avoid retrying late initialization if not set in Service API
- Late initialize top level DefaultUserSettings configs with `skip_incomplete_check` set to pickup changes from null to an empty object.
- Add checks verifying Domain resource has synced condition to e2e tests 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
