### PR TITLE
Late initialize ThroughputConfig to prevent unnecessary delta against default value

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-04-22T18:18:05Z"
-  build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
+  build_date: "2026-05-11T21:41:09Z"
+  build_hash: ece451c52fa72a9f7cfca3b086b8a4729b592ae4
   go_version: go1.26.2
-  version: v0.58.1
+  version: v0.58.1-4-gece451c
 api_directory_checksum: c4e5b363f35aec7f0c52278a9b963e41bb4a5fd5
 api_version: v1alpha1
 aws_sdk_go_version: v1.39.2
 generator_config_info:
-  file_checksum: bc61c421ad5643247c0be477c568af58b97f9d6e
+  file_checksum: cc083440fdec643ffd86984ffc277f432f1f962c
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -302,6 +302,9 @@ resources:
       OfflineStoreConfig.S3StorageConfig.ResolvedOutputS3URI:
         late_initialize:
           min_backoff_seconds: 5
+      ThroughputConfig:
+        late_initialize:
+          skip_incomplete_check: {}
       Tags:
         compare:
           is_ignored: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -302,6 +302,9 @@ resources:
       OfflineStoreConfig.S3StorageConfig.ResolvedOutputS3URI:
         late_initialize:
           min_backoff_seconds: 5
+      ThroughputConfig:
+        late_initialize:
+          skip_incomplete_check: {}
       Tags:
         compare:
           is_ignored: true

--- a/pkg/resource/feature_group/manager.go
+++ b/pkg/resource/feature_group/manager.go
@@ -50,7 +50,7 @@ var (
 // +kubebuilder:rbac:groups=sagemaker.services.k8s.aws,resources=featuregroups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=sagemaker.services.k8s.aws,resources=featuregroups/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"OfflineStoreConfig.DisableGlueTableCreation", "OfflineStoreConfig.S3StorageConfig.ResolvedOutputS3URI"}
+var lateInitializeFieldNames = []string{"OfflineStoreConfig.DisableGlueTableCreation", "OfflineStoreConfig.S3StorageConfig.ResolvedOutputS3URI", "ThroughputConfig"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -283,6 +283,9 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 				latestKo.Spec.OfflineStoreConfig.S3StorageConfig.ResolvedOutputS3URI = observedKo.Spec.OfflineStoreConfig.S3StorageConfig.ResolvedOutputS3URI
 			}
 		}
+	}
+	if observedKo.Spec.ThroughputConfig != nil && latestKo.Spec.ThroughputConfig == nil {
+		latestKo.Spec.ThroughputConfig = observedKo.Spec.ThroughputConfig
 	}
 	return &resource{latestKo}
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Our e2e test was failing due to a delta with `spec.throughputConfig` when unset against the default value set by AWS. This PR resolves this failure by updating the ACK controller to late initialize the ThroughputConfig fields when it unset. 

Example of the e2e test failure: https://prow.ack.aws.dev/view/s3/ack-prow-logs/pr-logs/pull/aws-controllers-k8s_runtime/234/sagemaker-controller-test/2052910685578334208

Relevant test controller logs:
```
2026-05-09T00:45:25.729Z	INFO	ackrt	desired resource state has changed	{"kind": "FeatureGroup", "namespace": "default", "name": "feature-group-gp8q8kg6jir2svmkew", "account": "", "role": "", "region": "us-west-2", "is_adopted": false, "generation": 2, "diff": [{"Path":{"Parts":["Spec","ThroughputConfig"]},"A":null,"B":{"throughputMode":"OnDemand"}}]}

...

2026-05-09T00:45:25.736Z	DEBUG	ackrt	patched resource status	{"kind": "FeatureGroup", "namespace": "default", "name": "feature-group-gp8q8kg6jir2svmkew", "account": "", "role": "", "region": "us-west-2", "is_adopted": false, "generation": 2, "json": "{\"metadata\":{\"resourceVersion\":\"1323\"},\"spec\":{\"tags\":[{\"key\":\"confidentiality\",\"value\":\"public\"},{\"key\":\"environment\",\"value\":\"testing\"},{\"key\":\"customer\",\"value\":\"test-user\"}]},\"status\":{\"conditions\":[{\"lastTransitionTime\":\"2026-05-09T00:45:25Z\",\"message\":\"FeatureGroup is in Creating status.\",\"status\":\"False\",\"type\":\"ACK.ResourceSynced\"},{\"message\":\"not implemented\",\"status\":\"True\",\"type\":\"ACK.Terminal\"},{\"lastTransitionTime\":\"2026-05-09T00:45:25Z\",\"message\":\"not implemented\",\"reason\":\"ACK.Terminal\",\"status\":\"False\",\"type\":\"Ready\"}]}}"}
``` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
