### PR TITLE
test: bump acktest to pick up credential rotation refresh

### DIFF
--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,4 +1,4 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@b9fd0d31598f7cc9e2952d9513501c6c2464b059
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@de3d4d970a1f6ae0b8ddf6c695e59b90446435a3
 pytest==8.0.2
 black>=24.3.0
 flaky==3.7.0


### PR DESCRIPTION
**Description of changes:**

Bumps the pinned `acktest` commit in `test/e2e/requirements.txt` from `b9fd0d3` to `de3d4d9` so the e2e tests pick up aws-controllers-k8s/test-infra#971.

**Why**

Long-running SageMaker e2e runs (e.g. `test_studio`, which runs late in a ~1h44m suite) intermittently fail with:

```
botocore.exceptions.ClientError: An error occurred (ExpiredTokenException) when calling the DescribeApp operation: The security token included in the request is expired
```

In Prow the test container is given static one-hour credentials in the `ack-test` profile, which the host rotates in place every 50 minutes. botocore caches a static-key profile for the life of the process, so the long-lived pytest process never picks up the rotated values and fails once the originals expire. test-infra#971 installs a refreshing credential provider in acktest to follow the rotation, but the old pin predates that change so the fix was never present in the image.

**Verification**

Once this lands, the e2e test log should show the provider being installed at startup:

```
INFO:root:acktest: installed rotating credential provider for profile 'ack-test' ...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
