### PR TITLE
fix: keep App unsynced until it reaches a stable status

### DIFF
--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -27,6 +27,17 @@ operations:
       RetainAllVariantProperties: aws.Bool(true)
 resources:
   App:
+    # An App transitions Pending -> InService asynchronously and has no Update
+    # API. Mark the resource synced only once it reaches a stable status so the
+    # runtime keeps requeueing (and refreshing the CR status) while it is still
+    # Pending, instead of treating a freshly-created App as synced and backing
+    # off to the long resync period.
+    synced:
+      when:
+        - path: Status.Status
+          in:
+            - InService
+            - Failed
     exceptions:
       errors:
         404:
@@ -37,8 +48,6 @@ resources:
         - InvalidParameterValue
         - MissingParameter
     hooks:
-      sdk_read_one_post_set_output:
-        code: rm.customDescribeAppSetOutput(ko)
       sdk_delete_pre_build_request:
         template_path: app/sdk_delete_pre_build_request.go.tpl
       sdk_delete_post_request:

--- a/generator.yaml
+++ b/generator.yaml
@@ -27,6 +27,17 @@ operations:
       RetainAllVariantProperties: aws.Bool(true)
 resources:
   App:
+    # An App transitions Pending -> InService asynchronously and has no Update
+    # API. Mark the resource synced only once it reaches a stable status so the
+    # runtime keeps requeueing (and refreshing the CR status) while it is still
+    # Pending, instead of treating a freshly-created App as synced and backing
+    # off to the long resync period.
+    synced:
+      when:
+        - path: Status.Status
+          in:
+            - InService
+            - Failed
     exceptions:
       errors:
         404:
@@ -37,8 +48,6 @@ resources:
         - InvalidParameterValue
         - MissingParameter
     hooks:
-      sdk_read_one_post_set_output:
-        code: rm.customDescribeAppSetOutput(ko)
       sdk_delete_pre_build_request:
         template_path: app/sdk_delete_pre_build_request.go.tpl
       sdk_delete_post_request:

--- a/pkg/resource/app/hook.go
+++ b/pkg/resource/app/hook.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
-	svcapitypes "github.com/aws-controllers-k8s/sagemaker-controller/apis/v1alpha1"
 	svccommon "github.com/aws-controllers-k8s/sagemaker-controller/pkg/common"
 	svcsdktypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 )
@@ -43,9 +42,4 @@ var (
 func (rm *resourceManager) requeueUntilCanModify(ctx context.Context, r *resource) error {
 	latestStatus := r.ko.Status.Status
 	return svccommon.RequeueIfModifying(latestStatus, &resourceName, &modifyingStatuses)
-}
-
-// Sets the ResourceSynced condition to False if resource is being modified by AWS
-func (rm *resourceManager) customDescribeAppSetOutput(ko *svcapitypes.App) {
-	svccommon.SetSyncedCondition(&resource{ko}, ko.Status.Status, &resourceName, &modifyingStatuses)
 }

--- a/pkg/resource/app/manager.go
+++ b/pkg/resource/app/manager.go
@@ -280,6 +280,14 @@ func (rm *resourceManager) IsSynced(ctx context.Context, res acktypes.AWSResourc
 		panic("resource manager's IsSynced() method received resource with nil CR object")
 	}
 
+	if r.ko.Status.Status == nil {
+		return false, nil
+	}
+	statusCandidates := []string{"InService", "Failed"}
+	if !ackutil.InStrings(*r.ko.Status.Status, statusCandidates) {
+		return false, nil
+	}
+
 	return true, nil
 }
 

--- a/pkg/resource/app/sdk.go
+++ b/pkg/resource/app/sdk.go
@@ -155,7 +155,6 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
-	rm.customDescribeAppSetOutput(ko)
 	return &resource{ko}, nil
 }
 


### PR DESCRIPTION
**Description of changes:**

A SageMaker Studio `App` transitions `Pending -> InService` asynchronously and has no Update API. The `ResourceSynced` condition was only set via a read-path custom hook (`sdk_read_one_post_set_output: rm.customDescribeAppSetOutput`). On the create reconcile that hook does not run, so the runtime fell back to the default generated `IsSynced` (which returns `true`), set `ResourceSynced=True`, and backed off to the long resync period (10h). The App's k8s `.status.status` then stayed `Pending` even though the App was already `InService` in AWS — it only converged on the next controller restart.

This is why `test_studio` appears to hang: the test waits for the App's k8s status to reach `InService`, which only happened when the periodic credential-rotation restart re-listed and re-reconciled everything (~tens of minutes later).

**Fix**

Replace the read-only custom synced hook with a declarative `synced` config:

```yaml
synced:
  when:
    - path: Status.Status
      in:
        - InService
        - Failed
```

The generated `IsSynced` now runs on every reconcile path (including right after Create). While the App is `Pending`, `ResourceSynced` stays `False`, so the runtime requeues (~30s) and keeps polling `DescribeApp`, reflecting the status in the CR promptly instead of waiting for a controller restart. `Failed` is included so a genuinely failed App is treated as a stable (synced) state and not requeued forever. The now-redundant `customDescribeAppSetOutput` hook is removed.

Generated with `make build-controller`. Changes are limited to the `App` resource.

**Testing**

`go build ./...` passes. The follow-up expectation is that `test_studio` no longer stalls waiting for the App k8s status to converge.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
