### PR TITLE
Mark Pipeline.PipelineDefinition as is_document

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-07-07T22:02:23Z"
+  build_date: "2026-07-08T00:53:44Z"
   build_hash: 0a6b791fa10a6140d862be334a6891868ee588eb
-  go_version: go1.26.4
+  go_version: go1.26.0
   version: v0.61.0
 api_directory_checksum: c4e5b363f35aec7f0c52278a9b963e41bb4a5fd5
 api_version: v1alpha1
 aws_sdk_go_version: v1.39.2
 generator_config_info:
-  file_checksum: cc083440fdec643ffd86984ffc277f432f1f962c
+  file_checksum: 6a72988a72fb9638b541c8bec98d4d811d29b64d
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -845,6 +845,8 @@ resources:
           is_ignored: true
   Pipeline:
     fields:
+      PipelineDefinition:
+        is_document: true
       PipelineStatus:
         is_read_only: true
         print:

--- a/generator.yaml
+++ b/generator.yaml
@@ -845,6 +845,8 @@ resources:
           is_ignored: true
   Pipeline:
     fields:
+      PipelineDefinition:
+        is_document: true
       PipelineStatus:
         is_read_only: true
         print:

--- a/pkg/resource/pipeline/delta.go
+++ b/pkg/resource/pipeline/delta.go
@@ -55,7 +55,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.PipelineDefinition, b.ko.Spec.PipelineDefinition) {
 		delta.Add("Spec.PipelineDefinition", a.ko.Spec.PipelineDefinition, b.ko.Spec.PipelineDefinition)
 	} else if a.ko.Spec.PipelineDefinition != nil && b.ko.Spec.PipelineDefinition != nil {
-		if *a.ko.Spec.PipelineDefinition != *b.ko.Spec.PipelineDefinition {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.PipelineDefinition, *b.ko.Spec.PipelineDefinition); err != nil || !equal {
 			delta.Add("Spec.PipelineDefinition", a.ko.Spec.PipelineDefinition, b.ko.Spec.PipelineDefinition)
 		}
 	}

--- a/test/e2e/tests/test_pipeline.py
+++ b/test/e2e/tests/test_pipeline.py
@@ -163,6 +163,16 @@ class TestPipeline:
         assert old_pipeline_last_modified_time != pipeline_desc["LastModifiedTime"]
         assert resource["status"].get("lastModifiedTime") != old_pipeline_last_modified_time
 
+        # Update pipelineDefinition to verify is_document comparison works
+        new_definition = '{"Version":"2020-12-01","Metadata":{},"Parameters":[],"Steps":[{"Name":"MyPassStep","Type":"Pass","Arguments":{}}]}'
+        spec["spec"]["pipelineDefinition"] = new_definition
+        resource = k8s.patch_custom_resource(reference, spec)
+        resource = k8s.wait_resource_consumed_by_controller(reference)
+        assert resource is not None
+        assert k8s.wait_on_condition(
+            reference, ack_condition.CONDITION_TYPE_RESOURCE_SYNCED, "True"
+        )
+
         resource_tags = resource["spec"].get("tags", None)
         assert_tags_in_sync(pipeline_arn, resource_tags)
 


### PR DESCRIPTION
## Summary

Adds `is_document: true` to the `Pipeline.PipelineDefinition` field in `generator.yaml`.

## Problem

The `Pipeline.PipelineDefinition` field accepts an Amazon SageMaker Pipeline JSON definition document. Without the `is_document` annotation, the controller uses strict string comparison, which causes false drift detection and infinite reconciliation loops when the API returns reformatted (but semantically equivalent) JSON.

## Changes

- Added `is_document: true` to `Pipeline.PipelineDefinition` in `generator.yaml`.
- Regenerated controller code — `pkg/resource/pipeline/delta.go` now uses `ackcompare.DocumentEqual` for semantic comparison.
- Added e2e coverage that updates `pipelineDefinition` and verifies the resource reaches `Synced`.

This is a clean re-implementation of #355 on top of the current `main` (runtime/code-generator `v0.61.0`). Regenerating against the matching code-generator version keeps the diff isolated to the intended change, avoiding the unrelated generated-file churn (e.g. `lateInitializeFieldNames` reformatting) that appeared in the earlier PR.

## Testing

- `go build -o bin/controller ./cmd/controller` — compiles cleanly.
- Existing e2e test (`pipeline.yaml` fixture) exercises the `pipelineDefinition` field with JSON content, plus the new update assertion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.